### PR TITLE
Added refilling of droppers that already have items

### DIFF
--- a/Brilliance Datapack/data/do2/functions/dungeon_setup/refill_droppers/all.mcfunction
+++ b/Brilliance Datapack/data/do2/functions/dungeon_setup/refill_droppers/all.mcfunction
@@ -1,17 +1,3483 @@
-# TODO:
+# Category "Artifact"
+## Example Item: "An Old Friend's Pickaxe (38)"
+data modify block -622 -51 1889 Items[0].Count set value 64b
+data modify block -622 -51 1889 Items[1].Count set value 64b
+data modify block -622 -51 1889 Items[2].Count set value 64b
+data modify block -622 -51 1889 Items[3].Count set value 64b
+data modify block -622 -51 1889 Items[4].Count set value 64b
+data modify block -622 -51 1889 Items[5].Count set value 64b
+data modify block -622 -51 1889 Items[6].Count set value 64b
+data modify block -622 -51 1889 Items[7].Count set value 64b
+data modify block -622 -51 1889 Items[8].Count set value 64b
 
-# Compasses
-# Maps
-# Suit Up
-# Porkchop Power
+## Example Item: "An Old Friend's Pickaxe (38)"
+data modify block -637 -51 1888 Items[0].Count set value 64b
+data modify block -637 -51 1888 Items[1].Count set value 64b
+data modify block -637 -51 1888 Items[2].Count set value 64b
+data modify block -637 -51 1888 Items[3].Count set value 64b
+data modify block -637 -51 1888 Items[4].Count set value 64b
+data modify block -637 -51 1888 Items[5].Count set value 64b
+data modify block -637 -51 1888 Items[6].Count set value 64b
+data modify block -637 -51 1888 Items[7].Count set value 64b
+data modify block -637 -51 1888 Items[8].Count set value 64b
 
-# Level Frost Embers
-# Level Treasure
-# Level Artifacts
+## Example Item: "An Old Friend's Pickaxe (38)"
+data modify block -659 -14 1922 Items[0].Count set value 64b
+data modify block -659 -14 1922 Items[1].Count set value 64b
+data modify block -659 -14 1922 Items[2].Count set value 64b
+data modify block -659 -14 1922 Items[3].Count set value 64b
+data modify block -659 -14 1922 Items[4].Count set value 64b
+data modify block -659 -14 1922 Items[5].Count set value 64b
+data modify block -659 -14 1922 Items[6].Count set value 64b
+data modify block -659 -14 1922 Items[7].Count set value 64b
+data modify block -659 -14 1922 Items[8].Count set value 64b
 
-# Rusty Repairs
-# Pirate Booty drops
-# Trick or Treats
+## Example Item: "Axe of the Screamin' Void (7)"
+data modify block -548 51 1972 Items[0].Count set value 64b
+data modify block -548 51 1972 Items[1].Count set value 64b
+data modify block -548 51 1972 Items[2].Count set value 64b
+data modify block -548 51 1972 Items[3].Count set value 64b
+data modify block -548 51 1972 Items[4].Count set value 64b
+data modify block -548 51 1972 Items[5].Count set value 64b
+data modify block -548 51 1972 Items[6].Count set value 64b
+data modify block -548 51 1972 Items[7].Count set value 64b
+data modify block -548 51 1972 Items[8].Count set value 64b
 
-# Level 4 Bombs
-# Level 4 secret room
+## Example Item: "Axe of the Screamin' Void (7)"
+data modify block -573 55 1944 Items[0].Count set value 64b
+data modify block -573 55 1944 Items[1].Count set value 64b
+data modify block -573 55 1944 Items[2].Count set value 64b
+data modify block -573 55 1944 Items[3].Count set value 64b
+data modify block -573 55 1944 Items[4].Count set value 64b
+data modify block -573 55 1944 Items[5].Count set value 64b
+data modify block -573 55 1944 Items[6].Count set value 64b
+data modify block -573 55 1944 Items[7].Count set value 64b
+data modify block -573 55 1944 Items[8].Count set value 64b
+
+## Example Item: "Axe of the Screamin' Void (7)"
+data modify block -593 49 1967 Items[0].Count set value 64b
+data modify block -593 49 1967 Items[1].Count set value 64b
+data modify block -593 49 1967 Items[2].Count set value 64b
+data modify block -593 49 1967 Items[3].Count set value 64b
+data modify block -593 49 1967 Items[4].Count set value 64b
+data modify block -593 49 1967 Items[5].Count set value 64b
+data modify block -593 49 1967 Items[6].Count set value 64b
+data modify block -593 49 1967 Items[7].Count set value 64b
+data modify block -593 49 1967 Items[8].Count set value 64b
+
+## Example Item: "Bionic Eye of Doom (24)"
+data modify block -588 -9 1917 Items[0].Count set value 64b
+data modify block -588 -9 1917 Items[1].Count set value 64b
+data modify block -588 -9 1917 Items[2].Count set value 64b
+data modify block -588 -9 1917 Items[3].Count set value 64b
+data modify block -588 -9 1917 Items[4].Count set value 64b
+data modify block -588 -9 1917 Items[5].Count set value 64b
+data modify block -588 -9 1917 Items[6].Count set value 64b
+data modify block -588 -9 1917 Items[7].Count set value 64b
+data modify block -588 -9 1917 Items[8].Count set value 64b
+
+## Example Item: "Bionic Eye of Doom (24)"
+data modify block -598 1 1890 Items[0].Count set value 64b
+data modify block -598 1 1890 Items[1].Count set value 64b
+data modify block -598 1 1890 Items[2].Count set value 64b
+data modify block -598 1 1890 Items[3].Count set value 64b
+data modify block -598 1 1890 Items[4].Count set value 64b
+data modify block -598 1 1890 Items[5].Count set value 64b
+data modify block -598 1 1890 Items[6].Count set value 64b
+data modify block -598 1 1890 Items[7].Count set value 64b
+data modify block -598 1 1890 Items[8].Count set value 64b
+
+## Example Item: "Bionic Eye of Doom (24)"
+data modify block -623 1 1892 Items[0].Count set value 64b
+data modify block -623 1 1892 Items[1].Count set value 64b
+data modify block -623 1 1892 Items[2].Count set value 64b
+data modify block -623 1 1892 Items[3].Count set value 64b
+data modify block -623 1 1892 Items[4].Count set value 64b
+data modify block -623 1 1892 Items[5].Count set value 64b
+data modify block -623 1 1892 Items[6].Count set value 64b
+data modify block -623 1 1892 Items[7].Count set value 64b
+data modify block -623 1 1892 Items[8].Count set value 64b
+
+## Example Item: "Butcher's Apron (20)"
+data modify block -519 12 1943 Items[0].Count set value 64b
+data modify block -519 12 1943 Items[1].Count set value 64b
+data modify block -519 12 1943 Items[2].Count set value 64b
+data modify block -519 12 1943 Items[3].Count set value 64b
+data modify block -519 12 1943 Items[4].Count set value 64b
+data modify block -519 12 1943 Items[5].Count set value 64b
+data modify block -519 12 1943 Items[6].Count set value 64b
+data modify block -519 12 1943 Items[7].Count set value 64b
+data modify block -519 12 1943 Items[8].Count set value 64b
+
+## Example Item: "Butcher's Apron (20)"
+data modify block -519 12 1982 Items[0].Count set value 64b
+data modify block -519 12 1982 Items[1].Count set value 64b
+data modify block -519 12 1982 Items[2].Count set value 64b
+data modify block -519 12 1982 Items[3].Count set value 64b
+data modify block -519 12 1982 Items[4].Count set value 64b
+data modify block -519 12 1982 Items[5].Count set value 64b
+data modify block -519 12 1982 Items[6].Count set value 64b
+data modify block -519 12 1982 Items[7].Count set value 64b
+data modify block -519 12 1982 Items[8].Count set value 64b
+
+## Example Item: "Butcher's Apron (20)"
+data modify block -534 12 1939 Items[0].Count set value 64b
+data modify block -534 12 1939 Items[1].Count set value 64b
+data modify block -534 12 1939 Items[2].Count set value 64b
+data modify block -534 12 1939 Items[3].Count set value 64b
+data modify block -534 12 1939 Items[4].Count set value 64b
+data modify block -534 12 1939 Items[5].Count set value 64b
+data modify block -534 12 1939 Items[6].Count set value 64b
+data modify block -534 12 1939 Items[7].Count set value 64b
+data modify block -534 12 1939 Items[8].Count set value 64b
+
+## Example Item: "CF-135 (46)"
+data modify block -574 -48 1910 Items[0].Count set value 64b
+data modify block -574 -48 1910 Items[1].Count set value 64b
+data modify block -574 -48 1910 Items[2].Count set value 64b
+data modify block -574 -48 1910 Items[3].Count set value 64b
+data modify block -574 -48 1910 Items[4].Count set value 64b
+data modify block -574 -48 1910 Items[5].Count set value 64b
+data modify block -574 -48 1910 Items[6].Count set value 64b
+data modify block -574 -48 1910 Items[7].Count set value 64b
+data modify block -574 -48 1910 Items[8].Count set value 64b
+
+## Example Item: "CF-135 (46)"
+data modify block -601 -49 1911 Items[0].Count set value 64b
+data modify block -601 -49 1911 Items[1].Count set value 64b
+data modify block -601 -49 1911 Items[2].Count set value 64b
+data modify block -601 -49 1911 Items[3].Count set value 64b
+data modify block -601 -49 1911 Items[4].Count set value 64b
+data modify block -601 -49 1911 Items[5].Count set value 64b
+data modify block -601 -49 1911 Items[6].Count set value 64b
+data modify block -601 -49 1911 Items[7].Count set value 64b
+data modify block -601 -49 1911 Items[8].Count set value 64b
+
+## Example Item: "CF-135 (46)"
+data modify block -607 -51 1863 Items[0].Count set value 64b
+data modify block -607 -51 1863 Items[1].Count set value 64b
+data modify block -607 -51 1863 Items[2].Count set value 64b
+data modify block -607 -51 1863 Items[3].Count set value 64b
+data modify block -607 -51 1863 Items[4].Count set value 64b
+data modify block -607 -51 1863 Items[5].Count set value 64b
+data modify block -607 -51 1863 Items[6].Count set value 64b
+data modify block -607 -51 1863 Items[7].Count set value 64b
+data modify block -607 -51 1863 Items[8].Count set value 64b
+
+## Example Item: "CF-135 (46)"
+data modify block -623 -52 1856 Items[0].Count set value 64b
+data modify block -623 -52 1856 Items[1].Count set value 64b
+data modify block -623 -52 1856 Items[2].Count set value 64b
+data modify block -623 -52 1856 Items[3].Count set value 64b
+data modify block -623 -52 1856 Items[4].Count set value 64b
+data modify block -623 -52 1856 Items[5].Count set value 64b
+data modify block -623 -52 1856 Items[6].Count set value 64b
+data modify block -623 -52 1856 Items[7].Count set value 64b
+data modify block -623 -52 1856 Items[8].Count set value 64b
+
+## Example Item: "Chisel of the Undead Sculptress (19)"
+data modify block -490 15 2002 Items[0].Count set value 64b
+data modify block -490 15 2002 Items[1].Count set value 64b
+data modify block -490 15 2002 Items[2].Count set value 64b
+data modify block -490 15 2002 Items[3].Count set value 64b
+data modify block -490 15 2002 Items[4].Count set value 64b
+data modify block -490 15 2002 Items[5].Count set value 64b
+data modify block -490 15 2002 Items[6].Count set value 64b
+data modify block -490 15 2002 Items[7].Count set value 64b
+data modify block -490 15 2002 Items[8].Count set value 64b
+
+## Example Item: "Chisel of the Undead Sculptress (19)"
+data modify block -537 16 2003 Items[0].Count set value 64b
+data modify block -537 16 2003 Items[1].Count set value 64b
+data modify block -537 16 2003 Items[2].Count set value 64b
+data modify block -537 16 2003 Items[3].Count set value 64b
+data modify block -537 16 2003 Items[4].Count set value 64b
+data modify block -537 16 2003 Items[5].Count set value 64b
+data modify block -537 16 2003 Items[6].Count set value 64b
+data modify block -537 16 2003 Items[7].Count set value 64b
+data modify block -537 16 2003 Items[8].Count set value 64b
+
+## Example Item: "Chisel of the Undead Sculptress (19)"
+data modify block -554 10 2024 Items[0].Count set value 64b
+data modify block -554 10 2024 Items[1].Count set value 64b
+data modify block -554 10 2024 Items[2].Count set value 64b
+data modify block -554 10 2024 Items[3].Count set value 64b
+data modify block -554 10 2024 Items[4].Count set value 64b
+data modify block -554 10 2024 Items[5].Count set value 64b
+data modify block -554 10 2024 Items[6].Count set value 64b
+data modify block -554 10 2024 Items[7].Count set value 64b
+data modify block -554 10 2024 Items[8].Count set value 64b
+
+## Example Item: "Death Loop (13)"
+data modify block -480 27 1992 Items[0].Count set value 64b
+data modify block -480 27 1992 Items[1].Count set value 64b
+data modify block -480 27 1992 Items[2].Count set value 64b
+data modify block -480 27 1992 Items[3].Count set value 64b
+data modify block -480 27 1992 Items[4].Count set value 64b
+data modify block -480 27 1992 Items[5].Count set value 64b
+data modify block -480 27 1992 Items[6].Count set value 64b
+data modify block -480 27 1992 Items[7].Count set value 64b
+data modify block -480 27 1992 Items[8].Count set value 64b
+
+## Example Item: "Death Loop (13)"
+data modify block -505 51 1962 Items[0].Count set value 64b
+data modify block -505 51 1962 Items[1].Count set value 64b
+data modify block -505 51 1962 Items[2].Count set value 64b
+data modify block -505 51 1962 Items[3].Count set value 64b
+data modify block -505 51 1962 Items[4].Count set value 64b
+data modify block -505 51 1962 Items[5].Count set value 64b
+data modify block -505 51 1962 Items[6].Count set value 64b
+data modify block -505 51 1962 Items[7].Count set value 64b
+data modify block -505 51 1962 Items[8].Count set value 64b
+
+## Example Item: "Death Loop (13)"
+data modify block -511 52 1958 Items[0].Count set value 64b
+data modify block -511 52 1958 Items[1].Count set value 64b
+data modify block -511 52 1958 Items[2].Count set value 64b
+data modify block -511 52 1958 Items[3].Count set value 64b
+data modify block -511 52 1958 Items[4].Count set value 64b
+data modify block -511 52 1958 Items[5].Count set value 64b
+data modify block -511 52 1958 Items[6].Count set value 64b
+data modify block -511 52 1958 Items[7].Count set value 64b
+data modify block -511 52 1958 Items[8].Count set value 64b
+
+## Example Item: "Gem of Greatness (40)"
+data modify block -590 -51 1899 Items[0].Count set value 64b
+data modify block -590 -51 1899 Items[1].Count set value 64b
+data modify block -590 -51 1899 Items[2].Count set value 64b
+data modify block -590 -51 1899 Items[3].Count set value 64b
+data modify block -590 -51 1899 Items[4].Count set value 64b
+data modify block -590 -51 1899 Items[5].Count set value 64b
+data modify block -590 -51 1899 Items[6].Count set value 64b
+data modify block -590 -51 1899 Items[7].Count set value 64b
+data modify block -590 -51 1899 Items[8].Count set value 64b
+
+## Example Item: "Gem of Greatness (40)"
+data modify block -601 -50 1890 Items[0].Count set value 64b
+data modify block -601 -50 1890 Items[1].Count set value 64b
+data modify block -601 -50 1890 Items[2].Count set value 64b
+data modify block -601 -50 1890 Items[3].Count set value 64b
+data modify block -601 -50 1890 Items[4].Count set value 64b
+data modify block -601 -50 1890 Items[5].Count set value 64b
+data modify block -601 -50 1890 Items[6].Count set value 64b
+data modify block -601 -50 1890 Items[7].Count set value 64b
+data modify block -601 -50 1890 Items[8].Count set value 64b
+
+## Example Item: "Golden Eye (34)"
+data modify block -580 -11 1892 Items[0].Count set value 64b
+data modify block -580 -11 1892 Items[1].Count set value 64b
+data modify block -580 -11 1892 Items[2].Count set value 64b
+data modify block -580 -11 1892 Items[3].Count set value 64b
+data modify block -580 -11 1892 Items[4].Count set value 64b
+data modify block -580 -11 1892 Items[5].Count set value 64b
+data modify block -580 -11 1892 Items[6].Count set value 64b
+data modify block -580 -11 1892 Items[7].Count set value 64b
+data modify block -580 -11 1892 Items[8].Count set value 64b
+
+## Example Item: "Golden Eye (34)"
+data modify block -582 -19 1896 Items[0].Count set value 64b
+data modify block -582 -19 1896 Items[1].Count set value 64b
+data modify block -582 -19 1896 Items[2].Count set value 64b
+data modify block -582 -19 1896 Items[3].Count set value 64b
+data modify block -582 -19 1896 Items[4].Count set value 64b
+data modify block -582 -19 1896 Items[5].Count set value 64b
+data modify block -582 -19 1896 Items[6].Count set value 64b
+data modify block -582 -19 1896 Items[7].Count set value 64b
+data modify block -582 -19 1896 Items[8].Count set value 64b
+
+## Example Item: "Golden Eye (34)"
+data modify block -589 -26 1898 Items[0].Count set value 64b
+data modify block -589 -26 1898 Items[1].Count set value 64b
+data modify block -589 -26 1898 Items[2].Count set value 64b
+data modify block -589 -26 1898 Items[3].Count set value 64b
+data modify block -589 -26 1898 Items[4].Count set value 64b
+data modify block -589 -26 1898 Items[5].Count set value 64b
+data modify block -589 -26 1898 Items[6].Count set value 64b
+data modify block -589 -26 1898 Items[7].Count set value 64b
+data modify block -589 -26 1898 Items[8].Count set value 64b
+
+## Example Item: "Hood of Aw'Yah (6)"
+data modify block -513 46 2030 Items[0].Count set value 64b
+data modify block -513 46 2030 Items[1].Count set value 64b
+data modify block -513 46 2030 Items[2].Count set value 64b
+data modify block -513 46 2030 Items[3].Count set value 64b
+data modify block -513 46 2030 Items[4].Count set value 64b
+data modify block -513 46 2030 Items[5].Count set value 64b
+data modify block -513 46 2030 Items[6].Count set value 64b
+data modify block -513 46 2030 Items[7].Count set value 64b
+data modify block -513 46 2030 Items[8].Count set value 64b
+
+## Example Item: "Hood of Aw'Yah (6)"
+data modify block -536 46 2035 Items[0].Count set value 64b
+data modify block -536 46 2035 Items[1].Count set value 64b
+data modify block -536 46 2035 Items[2].Count set value 64b
+data modify block -536 46 2035 Items[3].Count set value 64b
+data modify block -536 46 2035 Items[4].Count set value 64b
+data modify block -536 46 2035 Items[5].Count set value 64b
+data modify block -536 46 2035 Items[6].Count set value 64b
+data modify block -536 46 2035 Items[7].Count set value 64b
+data modify block -536 46 2035 Items[8].Count set value 64b
+
+## Example Item: "Hood of Aw'Yah (6)"
+data modify block -556 51 2006 Items[0].Count set value 64b
+data modify block -556 51 2006 Items[1].Count set value 64b
+data modify block -556 51 2006 Items[2].Count set value 64b
+data modify block -556 51 2006 Items[3].Count set value 64b
+data modify block -556 51 2006 Items[4].Count set value 64b
+data modify block -556 51 2006 Items[5].Count set value 64b
+data modify block -556 51 2006 Items[6].Count set value 64b
+data modify block -556 51 2006 Items[7].Count set value 64b
+data modify block -556 51 2006 Items[8].Count set value 64b
+
+## Example Item: "Hood of Aw'Yah (6)"
+data modify block -562 48 2033 Items[0].Count set value 64b
+data modify block -562 48 2033 Items[1].Count set value 64b
+data modify block -562 48 2033 Items[2].Count set value 64b
+data modify block -562 48 2033 Items[3].Count set value 64b
+data modify block -562 48 2033 Items[4].Count set value 64b
+data modify block -562 48 2033 Items[5].Count set value 64b
+data modify block -562 48 2033 Items[6].Count set value 64b
+data modify block -562 48 2033 Items[7].Count set value 64b
+data modify block -562 48 2033 Items[8].Count set value 64b
+
+## Example Item: "Horn of the G.O.A.T. (18)"
+data modify block -487 20 2008 Items[0].Count set value 64b
+data modify block -487 20 2008 Items[1].Count set value 64b
+data modify block -487 20 2008 Items[2].Count set value 64b
+data modify block -487 20 2008 Items[3].Count set value 64b
+data modify block -487 20 2008 Items[4].Count set value 64b
+data modify block -487 20 2008 Items[5].Count set value 64b
+data modify block -487 20 2008 Items[6].Count set value 64b
+data modify block -487 20 2008 Items[7].Count set value 64b
+data modify block -487 20 2008 Items[8].Count set value 64b
+
+## Example Item: "Horn of the G.O.A.T. (18)"
+data modify block -503 15 2033 Items[0].Count set value 64b
+data modify block -503 15 2033 Items[1].Count set value 64b
+data modify block -503 15 2033 Items[2].Count set value 64b
+data modify block -503 15 2033 Items[3].Count set value 64b
+data modify block -503 15 2033 Items[4].Count set value 64b
+data modify block -503 15 2033 Items[5].Count set value 64b
+data modify block -503 15 2033 Items[6].Count set value 64b
+data modify block -503 15 2033 Items[7].Count set value 64b
+data modify block -503 15 2033 Items[8].Count set value 64b
+
+## Example Item: "Horn of the G.O.A.T. (18)"
+data modify block -520 12 2025 Items[0].Count set value 64b
+data modify block -520 12 2025 Items[1].Count set value 64b
+data modify block -520 12 2025 Items[2].Count set value 64b
+data modify block -520 12 2025 Items[3].Count set value 64b
+data modify block -520 12 2025 Items[4].Count set value 64b
+data modify block -520 12 2025 Items[5].Count set value 64b
+data modify block -520 12 2025 Items[6].Count set value 64b
+data modify block -520 12 2025 Items[7].Count set value 64b
+data modify block -520 12 2025 Items[8].Count set value 64b
+
+## Example Item: "Hypnotic Bandana (21)"
+data modify block -572 9 1944 Items[0].Count set value 64b
+data modify block -572 9 1944 Items[1].Count set value 64b
+data modify block -572 9 1944 Items[2].Count set value 64b
+data modify block -572 9 1944 Items[3].Count set value 64b
+data modify block -572 9 1944 Items[4].Count set value 64b
+data modify block -572 9 1944 Items[5].Count set value 64b
+data modify block -572 9 1944 Items[6].Count set value 64b
+data modify block -572 9 1944 Items[7].Count set value 64b
+data modify block -572 9 1944 Items[8].Count set value 64b
+
+## Example Item: "Hypnotic Bandana (21)"
+data modify block -573 8 1966 Items[0].Count set value 64b
+data modify block -573 8 1966 Items[1].Count set value 64b
+data modify block -573 8 1966 Items[2].Count set value 64b
+data modify block -573 8 1966 Items[3].Count set value 64b
+data modify block -573 8 1966 Items[4].Count set value 64b
+data modify block -573 8 1966 Items[5].Count set value 64b
+data modify block -573 8 1966 Items[6].Count set value 64b
+data modify block -573 8 1966 Items[7].Count set value 64b
+data modify block -573 8 1966 Items[8].Count set value 64b
+
+## Example Item: "Hypnotic Bandana (21)"
+data modify block -588 13 1987 Items[0].Count set value 64b
+data modify block -588 13 1987 Items[1].Count set value 64b
+data modify block -588 13 1987 Items[2].Count set value 64b
+data modify block -588 13 1987 Items[3].Count set value 64b
+data modify block -588 13 1987 Items[4].Count set value 64b
+data modify block -588 13 1987 Items[5].Count set value 64b
+data modify block -588 13 1987 Items[6].Count set value 64b
+data modify block -588 13 1987 Items[7].Count set value 64b
+data modify block -588 13 1987 Items[8].Count set value 64b
+
+## Example Item: "Jar of Speedy Slime (11)"
+data modify block -517 52 2006 Items[0].Count set value 64b
+data modify block -517 52 2006 Items[1].Count set value 64b
+data modify block -517 52 2006 Items[2].Count set value 64b
+data modify block -517 52 2006 Items[3].Count set value 64b
+data modify block -517 52 2006 Items[4].Count set value 64b
+data modify block -517 52 2006 Items[5].Count set value 64b
+data modify block -517 52 2006 Items[6].Count set value 64b
+data modify block -517 52 2006 Items[7].Count set value 64b
+data modify block -517 52 2006 Items[8].Count set value 64b
+
+## Example Item: "Jar of Speedy Slime (11)"
+data modify block -525 51 1969 Items[0].Count set value 64b
+data modify block -525 51 1969 Items[1].Count set value 64b
+data modify block -525 51 1969 Items[2].Count set value 64b
+data modify block -525 51 1969 Items[3].Count set value 64b
+data modify block -525 51 1969 Items[4].Count set value 64b
+data modify block -525 51 1969 Items[5].Count set value 64b
+data modify block -525 51 1969 Items[6].Count set value 64b
+data modify block -525 51 1969 Items[7].Count set value 64b
+data modify block -525 51 1969 Items[8].Count set value 64b
+
+## Example Item: "Jar of Speedy Slime (11)"
+data modify block -543 44 1940 Items[0].Count set value 64b
+data modify block -543 44 1940 Items[1].Count set value 64b
+data modify block -543 44 1940 Items[2].Count set value 64b
+data modify block -543 44 1940 Items[3].Count set value 64b
+data modify block -543 44 1940 Items[4].Count set value 64b
+data modify block -543 44 1940 Items[5].Count set value 64b
+data modify block -543 44 1940 Items[6].Count set value 64b
+data modify block -543 44 1940 Items[7].Count set value 64b
+data modify block -543 44 1940 Items[8].Count set value 64b
+
+## Example Item: "Knight's Helm (23)"
+data modify block -571 12 2026 Items[0].Count set value 64b
+data modify block -571 12 2026 Items[1].Count set value 64b
+data modify block -571 12 2026 Items[2].Count set value 64b
+data modify block -571 12 2026 Items[3].Count set value 64b
+data modify block -571 12 2026 Items[4].Count set value 64b
+data modify block -571 12 2026 Items[5].Count set value 64b
+data modify block -571 12 2026 Items[6].Count set value 64b
+data modify block -571 12 2026 Items[7].Count set value 64b
+data modify block -571 12 2026 Items[8].Count set value 64b
+
+## Example Item: "Knight's Helm (23)"
+data modify block -574 15 2014 Items[0].Count set value 64b
+data modify block -574 15 2014 Items[1].Count set value 64b
+data modify block -574 15 2014 Items[2].Count set value 64b
+data modify block -574 15 2014 Items[3].Count set value 64b
+data modify block -574 15 2014 Items[4].Count set value 64b
+data modify block -574 15 2014 Items[5].Count set value 64b
+data modify block -574 15 2014 Items[6].Count set value 64b
+data modify block -574 15 2014 Items[7].Count set value 64b
+data modify block -574 15 2014 Items[8].Count set value 64b
+
+## Example Item: "Knight's Helm (23)"
+data modify block -599 12 2031 Items[0].Count set value 64b
+data modify block -599 12 2031 Items[1].Count set value 64b
+data modify block -599 12 2031 Items[2].Count set value 64b
+data modify block -599 12 2031 Items[3].Count set value 64b
+data modify block -599 12 2031 Items[4].Count set value 64b
+data modify block -599 12 2031 Items[5].Count set value 64b
+data modify block -599 12 2031 Items[6].Count set value 64b
+data modify block -599 12 2031 Items[7].Count set value 64b
+data modify block -599 12 2031 Items[8].Count set value 64b
+
+## Example Item: "Mug of the Dungeon Master (54)"
+data modify block -570 -51 1853 Items[0].Count set value 64b
+data modify block -570 -51 1853 Items[1].Count set value 64b
+data modify block -570 -51 1853 Items[2].Count set value 64b
+data modify block -570 -51 1853 Items[3].Count set value 64b
+data modify block -570 -51 1853 Items[4].Count set value 64b
+data modify block -570 -51 1853 Items[5].Count set value 64b
+data modify block -570 -51 1853 Items[6].Count set value 64b
+data modify block -570 -51 1853 Items[7].Count set value 64b
+data modify block -570 -51 1853 Items[8].Count set value 64b
+
+## Example Item: "Multi-Grain Waffle (8)"
+data modify block -490 50 2020 Items[0].Count set value 64b
+data modify block -490 50 2020 Items[1].Count set value 64b
+data modify block -490 50 2020 Items[2].Count set value 64b
+data modify block -490 50 2020 Items[3].Count set value 64b
+data modify block -490 50 2020 Items[4].Count set value 64b
+data modify block -490 50 2020 Items[5].Count set value 64b
+data modify block -490 50 2020 Items[6].Count set value 64b
+data modify block -490 50 2020 Items[7].Count set value 64b
+data modify block -490 50 2020 Items[8].Count set value 64b
+
+## Example Item: "Multi-Grain Waffle (8)"
+data modify block -499 44 2013 Items[0].Count set value 64b
+data modify block -499 44 2013 Items[1].Count set value 64b
+data modify block -499 44 2013 Items[2].Count set value 64b
+data modify block -499 44 2013 Items[3].Count set value 64b
+data modify block -499 44 2013 Items[4].Count set value 64b
+data modify block -499 44 2013 Items[5].Count set value 64b
+data modify block -499 44 2013 Items[6].Count set value 64b
+data modify block -499 44 2013 Items[7].Count set value 64b
+data modify block -499 44 2013 Items[8].Count set value 64b
+
+## Example Item: "Multi-Grain Waffle (8)"
+data modify block -546 38 1995 Items[0].Count set value 64b
+data modify block -546 38 1995 Items[1].Count set value 64b
+data modify block -546 38 1995 Items[2].Count set value 64b
+data modify block -546 38 1995 Items[3].Count set value 64b
+data modify block -546 38 1995 Items[4].Count set value 64b
+data modify block -546 38 1995 Items[5].Count set value 64b
+data modify block -546 38 1995 Items[6].Count set value 64b
+data modify block -546 38 1995 Items[7].Count set value 64b
+data modify block -546 38 1995 Items[8].Count set value 64b
+
+## Example Item: "Papa's Slippers (10)"
+data modify block -528 45 1956 Items[0].Count set value 64b
+data modify block -528 45 1956 Items[1].Count set value 64b
+data modify block -528 45 1956 Items[2].Count set value 64b
+data modify block -528 45 1956 Items[3].Count set value 64b
+data modify block -528 45 1956 Items[4].Count set value 64b
+data modify block -528 45 1956 Items[5].Count set value 64b
+data modify block -528 45 1956 Items[6].Count set value 64b
+data modify block -528 45 1956 Items[7].Count set value 64b
+data modify block -528 45 1956 Items[8].Count set value 64b
+
+## Example Item: "Papa's Slippers (10)"
+data modify block -536 44 1966 Items[0].Count set value 64b
+data modify block -536 44 1966 Items[1].Count set value 64b
+data modify block -536 44 1966 Items[2].Count set value 64b
+data modify block -536 44 1966 Items[3].Count set value 64b
+data modify block -536 44 1966 Items[4].Count set value 64b
+data modify block -536 44 1966 Items[5].Count set value 64b
+data modify block -536 44 1966 Items[6].Count set value 64b
+data modify block -536 44 1966 Items[7].Count set value 64b
+data modify block -536 44 1966 Items[8].Count set value 64b
+
+## Example Item: "Papa's Slippers (10)"
+data modify block -552 45 1955 Items[0].Count set value 64b
+data modify block -552 45 1955 Items[1].Count set value 64b
+data modify block -552 45 1955 Items[2].Count set value 64b
+data modify block -552 45 1955 Items[3].Count set value 64b
+data modify block -552 45 1955 Items[4].Count set value 64b
+data modify block -552 45 1955 Items[5].Count set value 64b
+data modify block -552 45 1955 Items[6].Count set value 64b
+data modify block -552 45 1955 Items[7].Count set value 64b
+data modify block -552 45 1955 Items[8].Count set value 64b
+
+## Example Item: "Pearl of Cleansing (14)"
+data modify block -452 18 1979 Items[0].Count set value 64b
+data modify block -452 18 1979 Items[1].Count set value 64b
+data modify block -452 18 1979 Items[2].Count set value 64b
+data modify block -452 18 1979 Items[3].Count set value 64b
+data modify block -452 18 1979 Items[4].Count set value 64b
+data modify block -452 18 1979 Items[5].Count set value 64b
+data modify block -452 18 1979 Items[6].Count set value 64b
+data modify block -452 18 1979 Items[7].Count set value 64b
+data modify block -452 18 1979 Items[8].Count set value 64b
+
+## Example Item: "Pearl of Cleansing (14)"
+data modify block -475 16 1962 Items[0].Count set value 64b
+data modify block -475 16 1962 Items[1].Count set value 64b
+data modify block -475 16 1962 Items[2].Count set value 64b
+data modify block -475 16 1962 Items[3].Count set value 64b
+data modify block -475 16 1962 Items[4].Count set value 64b
+data modify block -475 16 1962 Items[5].Count set value 64b
+data modify block -475 16 1962 Items[6].Count set value 64b
+data modify block -475 16 1962 Items[7].Count set value 64b
+data modify block -475 16 1962 Items[8].Count set value 64b
+
+## Example Item: "Pearl of Cleansing (14)"
+data modify block -484 18 2037 Items[0].Count set value 64b
+data modify block -484 18 2037 Items[1].Count set value 64b
+data modify block -484 18 2037 Items[2].Count set value 64b
+data modify block -484 18 2037 Items[3].Count set value 64b
+data modify block -484 18 2037 Items[4].Count set value 64b
+data modify block -484 18 2037 Items[5].Count set value 64b
+data modify block -484 18 2037 Items[6].Count set value 64b
+data modify block -484 18 2037 Items[7].Count set value 64b
+data modify block -484 18 2037 Items[8].Count set value 64b
+
+## Example Item: "Pocket Watch of Shreeping (36)"
+data modify block -598 -7 1881 Items[0].Count set value 64b
+data modify block -598 -7 1881 Items[1].Count set value 64b
+data modify block -598 -7 1881 Items[2].Count set value 64b
+data modify block -598 -7 1881 Items[3].Count set value 64b
+data modify block -598 -7 1881 Items[4].Count set value 64b
+data modify block -598 -7 1881 Items[5].Count set value 64b
+data modify block -598 -7 1881 Items[6].Count set value 64b
+data modify block -598 -7 1881 Items[7].Count set value 64b
+data modify block -598 -7 1881 Items[8].Count set value 64b
+
+## Example Item: "Pocket Watch of Shreeping (36)"
+data modify block -623 -19 1890 Items[0].Count set value 64b
+data modify block -623 -19 1890 Items[1].Count set value 64b
+data modify block -623 -19 1890 Items[2].Count set value 64b
+data modify block -623 -19 1890 Items[3].Count set value 64b
+data modify block -623 -19 1890 Items[4].Count set value 64b
+data modify block -623 -19 1890 Items[5].Count set value 64b
+data modify block -623 -19 1890 Items[6].Count set value 64b
+data modify block -623 -19 1890 Items[7].Count set value 64b
+data modify block -623 -19 1890 Items[8].Count set value 64b
+
+## Example Item: "Pocket Watch of Shreeping (36)"
+data modify block -648 -19 1893 Items[0].Count set value 64b
+data modify block -648 -19 1893 Items[1].Count set value 64b
+data modify block -648 -19 1893 Items[2].Count set value 64b
+data modify block -648 -19 1893 Items[3].Count set value 64b
+data modify block -648 -19 1893 Items[4].Count set value 64b
+data modify block -648 -19 1893 Items[5].Count set value 64b
+data modify block -648 -19 1893 Items[6].Count set value 64b
+data modify block -648 -19 1893 Items[7].Count set value 64b
+data modify block -648 -19 1893 Items[8].Count set value 64b
+
+## Example Item: "Shades of the Dog (9)"
+data modify block -517 35 1984 Items[0].Count set value 64b
+data modify block -517 35 1984 Items[1].Count set value 64b
+data modify block -517 35 1984 Items[2].Count set value 64b
+data modify block -517 35 1984 Items[3].Count set value 64b
+data modify block -517 35 1984 Items[4].Count set value 64b
+data modify block -517 35 1984 Items[5].Count set value 64b
+data modify block -517 35 1984 Items[6].Count set value 64b
+data modify block -517 35 1984 Items[7].Count set value 64b
+data modify block -517 35 1984 Items[8].Count set value 64b
+
+## Example Item: "Shades of the Dog (9)"
+data modify block -520 35 2000 Items[0].Count set value 64b
+data modify block -520 35 2000 Items[1].Count set value 64b
+data modify block -520 35 2000 Items[2].Count set value 64b
+data modify block -520 35 2000 Items[3].Count set value 64b
+data modify block -520 35 2000 Items[4].Count set value 64b
+data modify block -520 35 2000 Items[5].Count set value 64b
+data modify block -520 35 2000 Items[6].Count set value 64b
+data modify block -520 35 2000 Items[7].Count set value 64b
+data modify block -520 35 2000 Items[8].Count set value 64b
+
+## Example Item: "Shades of the Dog (9)"
+data modify block -550 38 1984 Items[0].Count set value 64b
+data modify block -550 38 1984 Items[1].Count set value 64b
+data modify block -550 38 1984 Items[2].Count set value 64b
+data modify block -550 38 1984 Items[3].Count set value 64b
+data modify block -550 38 1984 Items[4].Count set value 64b
+data modify block -550 38 1984 Items[5].Count set value 64b
+data modify block -550 38 1984 Items[6].Count set value 64b
+data modify block -550 38 1984 Items[7].Count set value 64b
+data modify block -550 38 1984 Items[8].Count set value 64b
+
+## Example Item: "Staff of the Pink Shepherd (48)"
+data modify block -599 -51 1842 Items[0].Count set value 64b
+data modify block -599 -51 1842 Items[1].Count set value 64b
+data modify block -599 -51 1842 Items[2].Count set value 64b
+data modify block -599 -51 1842 Items[3].Count set value 64b
+data modify block -599 -51 1842 Items[4].Count set value 64b
+data modify block -599 -51 1842 Items[5].Count set value 64b
+data modify block -599 -51 1842 Items[6].Count set value 64b
+data modify block -599 -51 1842 Items[7].Count set value 64b
+data modify block -599 -51 1842 Items[8].Count set value 64b
+
+## Example Item: "Staff of the Pink Shepherd (48)"
+data modify block -600 -51 1851 Items[0].Count set value 64b
+data modify block -600 -51 1851 Items[1].Count set value 64b
+data modify block -600 -51 1851 Items[2].Count set value 64b
+data modify block -600 -51 1851 Items[3].Count set value 64b
+data modify block -600 -51 1851 Items[4].Count set value 64b
+data modify block -600 -51 1851 Items[5].Count set value 64b
+data modify block -600 -51 1851 Items[6].Count set value 64b
+data modify block -600 -51 1851 Items[7].Count set value 64b
+data modify block -600 -51 1851 Items[8].Count set value 64b
+
+## Example Item: "Staff of the Pink Shepherd (48)"
+data modify block -623 -54 1842 Items[0].Count set value 64b
+data modify block -623 -54 1842 Items[1].Count set value 64b
+data modify block -623 -54 1842 Items[2].Count set value 64b
+data modify block -623 -54 1842 Items[3].Count set value 64b
+data modify block -623 -54 1842 Items[4].Count set value 64b
+data modify block -623 -54 1842 Items[5].Count set value 64b
+data modify block -623 -54 1842 Items[6].Count set value 64b
+data modify block -623 -54 1842 Items[7].Count set value 64b
+data modify block -623 -54 1842 Items[8].Count set value 64b
+
+## Example Item: "The Hidden Stache (30)"
+data modify block -604 -9 1914 Items[0].Count set value 64b
+data modify block -604 -9 1914 Items[1].Count set value 64b
+data modify block -604 -9 1914 Items[2].Count set value 64b
+data modify block -604 -9 1914 Items[3].Count set value 64b
+data modify block -604 -9 1914 Items[4].Count set value 64b
+data modify block -604 -9 1914 Items[5].Count set value 64b
+data modify block -604 -9 1914 Items[6].Count set value 64b
+data modify block -604 -9 1914 Items[7].Count set value 64b
+data modify block -604 -9 1914 Items[8].Count set value 64b
+
+## Example Item: "The Hidden Stache (30)"
+data modify block -635 -9 1890 Items[0].Count set value 64b
+data modify block -635 -9 1890 Items[1].Count set value 64b
+data modify block -635 -9 1890 Items[2].Count set value 64b
+data modify block -635 -9 1890 Items[3].Count set value 64b
+data modify block -635 -9 1890 Items[4].Count set value 64b
+data modify block -635 -9 1890 Items[5].Count set value 64b
+data modify block -635 -9 1890 Items[6].Count set value 64b
+data modify block -635 -9 1890 Items[7].Count set value 64b
+data modify block -635 -9 1890 Items[8].Count set value 64b
+
+## Example Item: "The Hidden Stache (30)"
+data modify block -651 1 1916 Items[0].Count set value 64b
+data modify block -651 1 1916 Items[1].Count set value 64b
+data modify block -651 1 1916 Items[2].Count set value 64b
+data modify block -651 1 1916 Items[3].Count set value 64b
+data modify block -651 1 1916 Items[4].Count set value 64b
+data modify block -651 1 1916 Items[5].Count set value 64b
+data modify block -651 1 1916 Items[6].Count set value 64b
+data modify block -651 1 1916 Items[7].Count set value 64b
+data modify block -651 1 1916 Items[8].Count set value 64b
+
+## Example Item: "The Master's Key (60)"
+data modify block -603 -60 1886 Items[0].Count set value 64b
+data modify block -603 -60 1886 Items[1].Count set value 64b
+data modify block -603 -60 1886 Items[2].Count set value 64b
+data modify block -603 -60 1886 Items[3].Count set value 64b
+data modify block -603 -60 1886 Items[4].Count set value 64b
+data modify block -603 -60 1886 Items[5].Count set value 64b
+data modify block -603 -60 1886 Items[6].Count set value 64b
+data modify block -603 -60 1886 Items[7].Count set value 64b
+data modify block -603 -60 1886 Items[8].Count set value 64b
+
+## Example Item: "The Skadoodler (52)"
+data modify block -590 -51 1864 Items[0].Count set value 64b
+data modify block -590 -51 1864 Items[1].Count set value 64b
+data modify block -590 -51 1864 Items[2].Count set value 64b
+data modify block -590 -51 1864 Items[3].Count set value 64b
+data modify block -590 -51 1864 Items[4].Count set value 64b
+data modify block -590 -51 1864 Items[5].Count set value 64b
+data modify block -590 -51 1864 Items[6].Count set value 64b
+data modify block -590 -51 1864 Items[7].Count set value 64b
+data modify block -590 -51 1864 Items[8].Count set value 64b
+
+## Example Item: "The Skadoodler (52)"
+data modify block -635 -51 1877 Items[0].Count set value 64b
+data modify block -635 -51 1877 Items[1].Count set value 64b
+data modify block -635 -51 1877 Items[2].Count set value 64b
+data modify block -635 -51 1877 Items[3].Count set value 64b
+data modify block -635 -51 1877 Items[4].Count set value 64b
+data modify block -635 -51 1877 Items[5].Count set value 64b
+data modify block -635 -51 1877 Items[6].Count set value 64b
+data modify block -635 -51 1877 Items[7].Count set value 64b
+data modify block -635 -51 1877 Items[8].Count set value 64b
+
+## Example Item: "The Skadoodler (52)"
+data modify block -636 -56 1842 Items[0].Count set value 64b
+data modify block -636 -56 1842 Items[1].Count set value 64b
+data modify block -636 -56 1842 Items[2].Count set value 64b
+data modify block -636 -56 1842 Items[3].Count set value 64b
+data modify block -636 -56 1842 Items[4].Count set value 64b
+data modify block -636 -56 1842 Items[5].Count set value 64b
+data modify block -636 -56 1842 Items[6].Count set value 64b
+data modify block -636 -56 1842 Items[7].Count set value 64b
+data modify block -636 -56 1842 Items[8].Count set value 64b
+
+## Example Item: "The Slab (50)"
+data modify block -568 -51 1878 Items[0].Count set value 64b
+data modify block -568 -51 1878 Items[1].Count set value 64b
+data modify block -568 -51 1878 Items[2].Count set value 64b
+data modify block -568 -51 1878 Items[3].Count set value 64b
+data modify block -568 -51 1878 Items[4].Count set value 64b
+data modify block -568 -51 1878 Items[5].Count set value 64b
+data modify block -568 -51 1878 Items[6].Count set value 64b
+data modify block -568 -51 1878 Items[7].Count set value 64b
+data modify block -568 -51 1878 Items[8].Count set value 64b
+
+## Example Item: "The Slab (50)"
+data modify block -569 -51 1884 Items[0].Count set value 64b
+data modify block -569 -51 1884 Items[1].Count set value 64b
+data modify block -569 -51 1884 Items[2].Count set value 64b
+data modify block -569 -51 1884 Items[3].Count set value 64b
+data modify block -569 -51 1884 Items[4].Count set value 64b
+data modify block -569 -51 1884 Items[5].Count set value 64b
+data modify block -569 -51 1884 Items[6].Count set value 64b
+data modify block -569 -51 1884 Items[7].Count set value 64b
+data modify block -569 -51 1884 Items[8].Count set value 64b
+
+## Example Item: "The Slab (50)"
+data modify block -591 -51 1870 Items[0].Count set value 64b
+data modify block -591 -51 1870 Items[1].Count set value 64b
+data modify block -591 -51 1870 Items[2].Count set value 64b
+data modify block -591 -51 1870 Items[3].Count set value 64b
+data modify block -591 -51 1870 Items[4].Count set value 64b
+data modify block -591 -51 1870 Items[5].Count set value 64b
+data modify block -591 -51 1870 Items[6].Count set value 64b
+data modify block -591 -51 1870 Items[7].Count set value 64b
+data modify block -591 -51 1870 Items[8].Count set value 64b
+
+## Example Item: "Tome of the Hills (12)"
+data modify block -497 51 1995 Items[0].Count set value 64b
+data modify block -497 51 1995 Items[1].Count set value 64b
+data modify block -497 51 1995 Items[2].Count set value 64b
+data modify block -497 51 1995 Items[3].Count set value 64b
+data modify block -497 51 1995 Items[4].Count set value 64b
+data modify block -497 51 1995 Items[5].Count set value 64b
+data modify block -497 51 1995 Items[6].Count set value 64b
+data modify block -497 51 1995 Items[7].Count set value 64b
+data modify block -497 51 1995 Items[8].Count set value 64b
+
+## Example Item: "Tome of the Hills (12)"
+data modify block -505 51 1981 Items[0].Count set value 64b
+data modify block -505 51 1981 Items[1].Count set value 64b
+data modify block -505 51 1981 Items[2].Count set value 64b
+data modify block -505 51 1981 Items[3].Count set value 64b
+data modify block -505 51 1981 Items[4].Count set value 64b
+data modify block -505 51 1981 Items[5].Count set value 64b
+data modify block -505 51 1981 Items[6].Count set value 64b
+data modify block -505 51 1981 Items[7].Count set value 64b
+data modify block -505 51 1981 Items[8].Count set value 64b
+
+## Example Item: "Tome of the Hills (12)"
+data modify block -543 51 2016 Items[0].Count set value 64b
+data modify block -543 51 2016 Items[1].Count set value 64b
+data modify block -543 51 2016 Items[2].Count set value 64b
+data modify block -543 51 2016 Items[3].Count set value 64b
+data modify block -543 51 2016 Items[4].Count set value 64b
+data modify block -543 51 2016 Items[5].Count set value 64b
+data modify block -543 51 2016 Items[6].Count set value 64b
+data modify block -543 51 2016 Items[7].Count set value 64b
+data modify block -543 51 2016 Items[8].Count set value 64b
+
+## Example Item: "Wand of Gorgeousness (22)"
+data modify block -505 23 1958 Items[0].Count set value 64b
+data modify block -505 23 1958 Items[1].Count set value 64b
+data modify block -505 23 1958 Items[2].Count set value 64b
+data modify block -505 23 1958 Items[3].Count set value 64b
+data modify block -505 23 1958 Items[4].Count set value 64b
+data modify block -505 23 1958 Items[5].Count set value 64b
+data modify block -505 23 1958 Items[6].Count set value 64b
+data modify block -505 23 1958 Items[7].Count set value 64b
+data modify block -505 23 1958 Items[8].Count set value 64b
+
+## Example Item: "Wand of Gorgeousness (22)"
+data modify block -549 10 1969 Items[0].Count set value 64b
+data modify block -549 10 1969 Items[1].Count set value 64b
+data modify block -549 10 1969 Items[2].Count set value 64b
+data modify block -549 10 1969 Items[3].Count set value 64b
+data modify block -549 10 1969 Items[4].Count set value 64b
+data modify block -549 10 1969 Items[5].Count set value 64b
+data modify block -549 10 1969 Items[6].Count set value 64b
+data modify block -549 10 1969 Items[7].Count set value 64b
+data modify block -549 10 1969 Items[8].Count set value 64b
+
+## Example Item: "Wand of Gorgeousness (22)"
+data modify block -575 13 1994 Items[0].Count set value 64b
+data modify block -575 13 1994 Items[1].Count set value 64b
+data modify block -575 13 1994 Items[2].Count set value 64b
+data modify block -575 13 1994 Items[3].Count set value 64b
+data modify block -575 13 1994 Items[4].Count set value 64b
+data modify block -575 13 1994 Items[5].Count set value 64b
+data modify block -575 13 1994 Items[6].Count set value 64b
+data modify block -575 13 1994 Items[7].Count set value 64b
+data modify block -575 13 1994 Items[8].Count set value 64b
+
+# Category "Artifakes"
+## Example Item: "An Old Friend's Pickaxe"
+data modify block -641 -23 1958 Items[0].Count set value 64b
+data modify block -641 -23 1958 Items[1].Count set value 64b
+data modify block -641 -23 1958 Items[2].Count set value 64b
+data modify block -641 -23 1958 Items[3].Count set value 64b
+data modify block -641 -23 1958 Items[4].Count set value 64b
+data modify block -641 -23 1958 Items[5].Count set value 64b
+data modify block -641 -23 1958 Items[6].Count set value 64b
+data modify block -641 -23 1958 Items[7].Count set value 64b
+data modify block -641 -23 1958 Items[8].Count set value 64b
+
+## Example Item: "Axe of the Screamin' Void"
+data modify block -641 -23 1977 Items[0].Count set value 64b
+data modify block -641 -23 1977 Items[1].Count set value 64b
+data modify block -641 -23 1977 Items[2].Count set value 64b
+data modify block -641 -23 1977 Items[3].Count set value 64b
+data modify block -641 -23 1977 Items[4].Count set value 64b
+data modify block -641 -23 1977 Items[5].Count set value 64b
+data modify block -641 -23 1977 Items[6].Count set value 64b
+data modify block -641 -23 1977 Items[7].Count set value 64b
+data modify block -641 -23 1977 Items[8].Count set value 64b
+
+## Example Item: "Bionic Eye of Doom"
+data modify block -641 -23 1963 Items[0].Count set value 64b
+data modify block -641 -23 1963 Items[1].Count set value 64b
+data modify block -641 -23 1963 Items[2].Count set value 64b
+data modify block -641 -23 1963 Items[3].Count set value 64b
+data modify block -641 -23 1963 Items[4].Count set value 64b
+data modify block -641 -23 1963 Items[5].Count set value 64b
+data modify block -641 -23 1963 Items[6].Count set value 64b
+data modify block -641 -23 1963 Items[7].Count set value 64b
+data modify block -641 -23 1963 Items[8].Count set value 64b
+
+## Example Item: "Butcher's Apron"
+data modify block -641 -23 1967 Items[0].Count set value 64b
+data modify block -641 -23 1967 Items[1].Count set value 64b
+data modify block -641 -23 1967 Items[2].Count set value 64b
+data modify block -641 -23 1967 Items[3].Count set value 64b
+data modify block -641 -23 1967 Items[4].Count set value 64b
+data modify block -641 -23 1967 Items[5].Count set value 64b
+data modify block -641 -23 1967 Items[6].Count set value 64b
+data modify block -641 -23 1967 Items[7].Count set value 64b
+data modify block -641 -23 1967 Items[8].Count set value 64b
+
+## Example Item: "CF-135"
+data modify block -641 -23 1956 Items[0].Count set value 64b
+data modify block -641 -23 1956 Items[1].Count set value 64b
+data modify block -641 -23 1956 Items[2].Count set value 64b
+data modify block -641 -23 1956 Items[3].Count set value 64b
+data modify block -641 -23 1956 Items[4].Count set value 64b
+data modify block -641 -23 1956 Items[5].Count set value 64b
+data modify block -641 -23 1956 Items[6].Count set value 64b
+data modify block -641 -23 1956 Items[7].Count set value 64b
+data modify block -641 -23 1956 Items[8].Count set value 64b
+
+## Example Item: "Chisel of the Undead Sculptress"
+data modify block -641 -23 1968 Items[0].Count set value 64b
+data modify block -641 -23 1968 Items[1].Count set value 64b
+data modify block -641 -23 1968 Items[2].Count set value 64b
+data modify block -641 -23 1968 Items[3].Count set value 64b
+data modify block -641 -23 1968 Items[4].Count set value 64b
+data modify block -641 -23 1968 Items[5].Count set value 64b
+data modify block -641 -23 1968 Items[6].Count set value 64b
+data modify block -641 -23 1968 Items[7].Count set value 64b
+data modify block -641 -23 1968 Items[8].Count set value 64b
+
+## Example Item: "Death Loop"
+data modify block -641 -23 1971 Items[0].Count set value 64b
+data modify block -641 -23 1971 Items[1].Count set value 64b
+data modify block -641 -23 1971 Items[2].Count set value 64b
+data modify block -641 -23 1971 Items[3].Count set value 64b
+data modify block -641 -23 1971 Items[4].Count set value 64b
+data modify block -641 -23 1971 Items[5].Count set value 64b
+data modify block -641 -23 1971 Items[6].Count set value 64b
+data modify block -641 -23 1971 Items[7].Count set value 64b
+data modify block -641 -23 1971 Items[8].Count set value 64b
+
+## Example Item: "Gem of Greatness"
+data modify block -641 -23 1957 Items[0].Count set value 64b
+data modify block -641 -23 1957 Items[1].Count set value 64b
+data modify block -641 -23 1957 Items[2].Count set value 64b
+data modify block -641 -23 1957 Items[3].Count set value 64b
+data modify block -641 -23 1957 Items[4].Count set value 64b
+data modify block -641 -23 1957 Items[5].Count set value 64b
+data modify block -641 -23 1957 Items[6].Count set value 64b
+data modify block -641 -23 1957 Items[7].Count set value 64b
+data modify block -641 -23 1957 Items[8].Count set value 64b
+
+## Example Item: "Goggles of Symmetry"
+data modify block -641 -23 1961 Items[0].Count set value 64b
+data modify block -641 -23 1961 Items[1].Count set value 64b
+data modify block -641 -23 1961 Items[2].Count set value 64b
+data modify block -641 -23 1961 Items[3].Count set value 64b
+data modify block -641 -23 1961 Items[4].Count set value 64b
+data modify block -641 -23 1961 Items[5].Count set value 64b
+data modify block -641 -23 1961 Items[6].Count set value 64b
+data modify block -641 -23 1961 Items[7].Count set value 64b
+data modify block -641 -23 1961 Items[8].Count set value 64b
+
+## Example Item: "Golden Eye"
+data modify block -641 -23 1960 Items[0].Count set value 64b
+data modify block -641 -23 1960 Items[1].Count set value 64b
+data modify block -641 -23 1960 Items[2].Count set value 64b
+data modify block -641 -23 1960 Items[3].Count set value 64b
+data modify block -641 -23 1960 Items[4].Count set value 64b
+data modify block -641 -23 1960 Items[5].Count set value 64b
+data modify block -641 -23 1960 Items[6].Count set value 64b
+data modify block -641 -23 1960 Items[7].Count set value 64b
+data modify block -641 -23 1960 Items[8].Count set value 64b
+
+## Example Item: "Hood of Aw'Yah"
+data modify block -641 -23 1978 Items[0].Count set value 64b
+data modify block -641 -23 1978 Items[1].Count set value 64b
+data modify block -641 -23 1978 Items[2].Count set value 64b
+data modify block -641 -23 1978 Items[3].Count set value 64b
+data modify block -641 -23 1978 Items[4].Count set value 64b
+data modify block -641 -23 1978 Items[5].Count set value 64b
+data modify block -641 -23 1978 Items[6].Count set value 64b
+data modify block -641 -23 1978 Items[7].Count set value 64b
+data modify block -641 -23 1978 Items[8].Count set value 64b
+
+## Example Item: "Horn of the G.O.A.T."
+data modify block -641 -23 1969 Items[0].Count set value 64b
+data modify block -641 -23 1969 Items[1].Count set value 64b
+data modify block -641 -23 1969 Items[2].Count set value 64b
+data modify block -641 -23 1969 Items[3].Count set value 64b
+data modify block -641 -23 1969 Items[4].Count set value 64b
+data modify block -641 -23 1969 Items[5].Count set value 64b
+data modify block -641 -23 1969 Items[6].Count set value 64b
+data modify block -641 -23 1969 Items[7].Count set value 64b
+data modify block -641 -23 1969 Items[8].Count set value 64b
+
+## Example Item: "Hypnotic Bandana"
+data modify block -641 -23 1966 Items[0].Count set value 64b
+data modify block -641 -23 1966 Items[1].Count set value 64b
+data modify block -641 -23 1966 Items[2].Count set value 64b
+data modify block -641 -23 1966 Items[3].Count set value 64b
+data modify block -641 -23 1966 Items[4].Count set value 64b
+data modify block -641 -23 1966 Items[5].Count set value 64b
+data modify block -641 -23 1966 Items[6].Count set value 64b
+data modify block -641 -23 1966 Items[7].Count set value 64b
+data modify block -641 -23 1966 Items[8].Count set value 64b
+
+## Example Item: "Jar of Speedy Slime"
+data modify block -641 -23 1973 Items[0].Count set value 64b
+data modify block -641 -23 1973 Items[1].Count set value 64b
+data modify block -641 -23 1973 Items[2].Count set value 64b
+data modify block -641 -23 1973 Items[3].Count set value 64b
+data modify block -641 -23 1973 Items[4].Count set value 64b
+data modify block -641 -23 1973 Items[5].Count set value 64b
+data modify block -641 -23 1973 Items[6].Count set value 64b
+data modify block -641 -23 1973 Items[7].Count set value 64b
+data modify block -641 -23 1973 Items[8].Count set value 64b
+
+## Example Item: "Knight's Helm"
+data modify block -641 -23 1964 Items[0].Count set value 64b
+data modify block -641 -23 1964 Items[1].Count set value 64b
+data modify block -641 -23 1964 Items[2].Count set value 64b
+data modify block -641 -23 1964 Items[3].Count set value 64b
+data modify block -641 -23 1964 Items[4].Count set value 64b
+data modify block -641 -23 1964 Items[5].Count set value 64b
+data modify block -641 -23 1964 Items[6].Count set value 64b
+data modify block -641 -23 1964 Items[7].Count set value 64b
+data modify block -641 -23 1964 Items[8].Count set value 64b
+
+## Example Item: "Mug of the Dungeon Master"
+data modify block -641 -23 1952 Items[0].Count set value 64b
+data modify block -641 -23 1952 Items[1].Count set value 64b
+data modify block -641 -23 1952 Items[2].Count set value 64b
+data modify block -641 -23 1952 Items[3].Count set value 64b
+data modify block -641 -23 1952 Items[4].Count set value 64b
+data modify block -641 -23 1952 Items[5].Count set value 64b
+data modify block -641 -23 1952 Items[6].Count set value 64b
+data modify block -641 -23 1952 Items[7].Count set value 64b
+data modify block -641 -23 1952 Items[8].Count set value 64b
+
+## Example Item: "Multi-Grain Waffle"
+data modify block -641 -23 1976 Items[0].Count set value 64b
+data modify block -641 -23 1976 Items[1].Count set value 64b
+data modify block -641 -23 1976 Items[2].Count set value 64b
+data modify block -641 -23 1976 Items[3].Count set value 64b
+data modify block -641 -23 1976 Items[4].Count set value 64b
+data modify block -641 -23 1976 Items[5].Count set value 64b
+data modify block -641 -23 1976 Items[6].Count set value 64b
+data modify block -641 -23 1976 Items[7].Count set value 64b
+data modify block -641 -23 1976 Items[8].Count set value 64b
+
+## Example Item: "Papa's Slippers"
+data modify block -641 -23 1974 Items[0].Count set value 64b
+data modify block -641 -23 1974 Items[1].Count set value 64b
+data modify block -641 -23 1974 Items[2].Count set value 64b
+data modify block -641 -23 1974 Items[3].Count set value 64b
+data modify block -641 -23 1974 Items[4].Count set value 64b
+data modify block -641 -23 1974 Items[5].Count set value 64b
+data modify block -641 -23 1974 Items[6].Count set value 64b
+data modify block -641 -23 1974 Items[7].Count set value 64b
+data modify block -641 -23 1974 Items[8].Count set value 64b
+
+## Example Item: "Pearl of Cleansing"
+data modify block -641 -23 1970 Items[0].Count set value 64b
+data modify block -641 -23 1970 Items[1].Count set value 64b
+data modify block -641 -23 1970 Items[2].Count set value 64b
+data modify block -641 -23 1970 Items[3].Count set value 64b
+data modify block -641 -23 1970 Items[4].Count set value 64b
+data modify block -641 -23 1970 Items[5].Count set value 64b
+data modify block -641 -23 1970 Items[6].Count set value 64b
+data modify block -641 -23 1970 Items[7].Count set value 64b
+data modify block -641 -23 1970 Items[8].Count set value 64b
+
+## Example Item: "Pocket Watch of Shreeping"
+data modify block -641 -23 1959 Items[0].Count set value 64b
+data modify block -641 -23 1959 Items[1].Count set value 64b
+data modify block -641 -23 1959 Items[2].Count set value 64b
+data modify block -641 -23 1959 Items[3].Count set value 64b
+data modify block -641 -23 1959 Items[4].Count set value 64b
+data modify block -641 -23 1959 Items[5].Count set value 64b
+data modify block -641 -23 1959 Items[6].Count set value 64b
+data modify block -641 -23 1959 Items[7].Count set value 64b
+data modify block -641 -23 1959 Items[8].Count set value 64b
+
+## Example Item: "Shades of the Dog"
+data modify block -641 -23 1975 Items[0].Count set value 64b
+data modify block -641 -23 1975 Items[1].Count set value 64b
+data modify block -641 -23 1975 Items[2].Count set value 64b
+data modify block -641 -23 1975 Items[3].Count set value 64b
+data modify block -641 -23 1975 Items[4].Count set value 64b
+data modify block -641 -23 1975 Items[5].Count set value 64b
+data modify block -641 -23 1975 Items[6].Count set value 64b
+data modify block -641 -23 1975 Items[7].Count set value 64b
+data modify block -641 -23 1975 Items[8].Count set value 64b
+
+## Example Item: "Staff of the Pink Shepherd"
+data modify block -641 -23 1955 Items[0].Count set value 64b
+data modify block -641 -23 1955 Items[1].Count set value 64b
+data modify block -641 -23 1955 Items[2].Count set value 64b
+data modify block -641 -23 1955 Items[3].Count set value 64b
+data modify block -641 -23 1955 Items[4].Count set value 64b
+data modify block -641 -23 1955 Items[5].Count set value 64b
+data modify block -641 -23 1955 Items[6].Count set value 64b
+data modify block -641 -23 1955 Items[7].Count set value 64b
+data modify block -641 -23 1955 Items[8].Count set value 64b
+
+## Example Item: "The Hidden Stache"
+data modify block -641 -23 1962 Items[0].Count set value 64b
+data modify block -641 -23 1962 Items[1].Count set value 64b
+data modify block -641 -23 1962 Items[2].Count set value 64b
+data modify block -641 -23 1962 Items[3].Count set value 64b
+data modify block -641 -23 1962 Items[4].Count set value 64b
+data modify block -641 -23 1962 Items[5].Count set value 64b
+data modify block -641 -23 1962 Items[6].Count set value 64b
+data modify block -641 -23 1962 Items[7].Count set value 64b
+data modify block -641 -23 1962 Items[8].Count set value 64b
+
+## Example Item: "The Master's Key"
+data modify block -641 -23 1951 Items[0].Count set value 64b
+data modify block -641 -23 1951 Items[1].Count set value 64b
+data modify block -641 -23 1951 Items[2].Count set value 64b
+data modify block -641 -23 1951 Items[3].Count set value 64b
+data modify block -641 -23 1951 Items[4].Count set value 64b
+data modify block -641 -23 1951 Items[5].Count set value 64b
+data modify block -641 -23 1951 Items[6].Count set value 64b
+data modify block -641 -23 1951 Items[7].Count set value 64b
+data modify block -641 -23 1951 Items[8].Count set value 64b
+
+## Example Item: "The Skadoodler"
+data modify block -641 -23 1953 Items[0].Count set value 64b
+data modify block -641 -23 1953 Items[1].Count set value 64b
+data modify block -641 -23 1953 Items[2].Count set value 64b
+data modify block -641 -23 1953 Items[3].Count set value 64b
+data modify block -641 -23 1953 Items[4].Count set value 64b
+data modify block -641 -23 1953 Items[5].Count set value 64b
+data modify block -641 -23 1953 Items[6].Count set value 64b
+data modify block -641 -23 1953 Items[7].Count set value 64b
+data modify block -641 -23 1953 Items[8].Count set value 64b
+
+## Example Item: "The Slab"
+data modify block -641 -23 1954 Items[0].Count set value 64b
+data modify block -641 -23 1954 Items[1].Count set value 64b
+data modify block -641 -23 1954 Items[2].Count set value 64b
+data modify block -641 -23 1954 Items[3].Count set value 64b
+data modify block -641 -23 1954 Items[4].Count set value 64b
+data modify block -641 -23 1954 Items[5].Count set value 64b
+data modify block -641 -23 1954 Items[6].Count set value 64b
+data modify block -641 -23 1954 Items[7].Count set value 64b
+data modify block -641 -23 1954 Items[8].Count set value 64b
+
+## Example Item: "Tome of the Hills"
+data modify block -641 -23 1972 Items[0].Count set value 64b
+data modify block -641 -23 1972 Items[1].Count set value 64b
+data modify block -641 -23 1972 Items[2].Count set value 64b
+data modify block -641 -23 1972 Items[3].Count set value 64b
+data modify block -641 -23 1972 Items[4].Count set value 64b
+data modify block -641 -23 1972 Items[5].Count set value 64b
+data modify block -641 -23 1972 Items[6].Count set value 64b
+data modify block -641 -23 1972 Items[7].Count set value 64b
+data modify block -641 -23 1972 Items[8].Count set value 64b
+
+## Example Item: "Wand of Gorgeousness"
+data modify block -641 -23 1965 Items[0].Count set value 64b
+data modify block -641 -23 1965 Items[1].Count set value 64b
+data modify block -641 -23 1965 Items[2].Count set value 64b
+data modify block -641 -23 1965 Items[3].Count set value 64b
+data modify block -641 -23 1965 Items[4].Count set value 64b
+data modify block -641 -23 1965 Items[5].Count set value 64b
+data modify block -641 -23 1965 Items[6].Count set value 64b
+data modify block -641 -23 1965 Items[7].Count set value 64b
+data modify block -641 -23 1965 Items[8].Count set value 64b
+
+# Category "Cards"
+## Example Item: "Adrenaline Rush"
+data modify block -630 -20 2014 Items[0].Count set value 64b
+data modify block -630 -20 2014 Items[1].Count set value 64b
+data modify block -630 -20 2014 Items[2].Count set value 64b
+data modify block -630 -20 2014 Items[3].Count set value 64b
+data modify block -630 -20 2014 Items[4].Count set value 64b
+data modify block -630 -20 2014 Items[5].Count set value 64b
+data modify block -630 -20 2014 Items[6].Count set value 64b
+data modify block -630 -20 2014 Items[7].Count set value 64b
+data modify block -630 -20 2014 Items[8].Count set value 64b
+
+## Example Item: "Beast Sense"
+data modify block -630 -20 2004 Items[0].Count set value 64b
+data modify block -630 -20 2004 Items[1].Count set value 64b
+data modify block -630 -20 2004 Items[2].Count set value 64b
+data modify block -630 -20 2004 Items[3].Count set value 64b
+data modify block -630 -20 2004 Items[4].Count set value 64b
+data modify block -630 -20 2004 Items[5].Count set value 64b
+data modify block -630 -20 2004 Items[6].Count set value 64b
+data modify block -630 -20 2004 Items[7].Count set value 64b
+data modify block -630 -20 2004 Items[8].Count set value 64b
+
+## Example Item: "Bounding Strides"
+data modify block -630 -20 2005 Items[0].Count set value 64b
+data modify block -630 -20 2005 Items[1].Count set value 64b
+data modify block -630 -20 2005 Items[2].Count set value 64b
+data modify block -630 -20 2005 Items[3].Count set value 64b
+data modify block -630 -20 2005 Items[4].Count set value 64b
+data modify block -630 -20 2005 Items[5].Count set value 64b
+data modify block -630 -20 2005 Items[6].Count set value 64b
+data modify block -630 -20 2005 Items[7].Count set value 64b
+data modify block -630 -20 2005 Items[8].Count set value 64b
+
+## Example Item: "Ember Seeker"
+data modify block -630 -20 1995 Items[0].Count set value 64b
+data modify block -630 -20 1995 Items[1].Count set value 64b
+data modify block -630 -20 1995 Items[2].Count set value 64b
+data modify block -630 -20 1995 Items[3].Count set value 64b
+data modify block -630 -20 1995 Items[4].Count set value 64b
+data modify block -630 -20 1995 Items[5].Count set value 64b
+data modify block -630 -20 1995 Items[6].Count set value 64b
+data modify block -630 -20 1995 Items[7].Count set value 64b
+data modify block -630 -20 1995 Items[8].Count set value 64b
+
+## Example Item: "Evasion"
+data modify block -630 -20 1998 Items[0].Count set value 64b
+data modify block -630 -20 1998 Items[1].Count set value 64b
+data modify block -630 -20 1998 Items[2].Count set value 64b
+data modify block -630 -20 1998 Items[3].Count set value 64b
+data modify block -630 -20 1998 Items[4].Count set value 64b
+data modify block -630 -20 1998 Items[5].Count set value 64b
+data modify block -630 -20 1998 Items[6].Count set value 64b
+data modify block -630 -20 1998 Items[7].Count set value 64b
+data modify block -630 -20 1998 Items[8].Count set value 64b
+
+## Example Item: "Frost Focus"
+data modify block -630 -20 2001 Items[0].Count set value 64b
+data modify block -630 -20 2001 Items[1].Count set value 64b
+data modify block -630 -20 2001 Items[2].Count set value 64b
+data modify block -630 -20 2001 Items[3].Count set value 64b
+data modify block -630 -20 2001 Items[4].Count set value 64b
+data modify block -630 -20 2001 Items[5].Count set value 64b
+data modify block -630 -20 2001 Items[6].Count set value 64b
+data modify block -630 -20 2001 Items[7].Count set value 64b
+data modify block -630 -20 2001 Items[8].Count set value 64b
+
+## Example Item: "Loot and Scoot"
+data modify block -630 -20 2000 Items[0].Count set value 64b
+data modify block -630 -20 2000 Items[1].Count set value 64b
+data modify block -630 -20 2000 Items[2].Count set value 64b
+data modify block -630 -20 2000 Items[3].Count set value 64b
+data modify block -630 -20 2000 Items[4].Count set value 64b
+data modify block -630 -20 2000 Items[5].Count set value 64b
+data modify block -630 -20 2000 Items[6].Count set value 64b
+data modify block -630 -20 2000 Items[7].Count set value 64b
+data modify block -630 -20 2000 Items[8].Count set value 64b
+
+## Example Item: "Moment of Clarity"
+data modify block -630 -20 1996 Items[0].Count set value 64b
+data modify block -630 -20 1996 Items[1].Count set value 64b
+data modify block -630 -20 1996 Items[2].Count set value 64b
+data modify block -630 -20 1996 Items[3].Count set value 64b
+data modify block -630 -20 1996 Items[4].Count set value 64b
+data modify block -630 -20 1996 Items[5].Count set value 64b
+data modify block -630 -20 1996 Items[6].Count set value 64b
+data modify block -630 -20 1996 Items[7].Count set value 64b
+data modify block -630 -20 1996 Items[8].Count set value 64b
+
+## Example Item: "Nimble Looting"
+data modify block -630 -20 2010 Items[0].Count set value 64b
+data modify block -630 -20 2010 Items[1].Count set value 64b
+data modify block -630 -20 2010 Items[2].Count set value 64b
+data modify block -630 -20 2010 Items[3].Count set value 64b
+data modify block -630 -20 2010 Items[4].Count set value 64b
+data modify block -630 -20 2010 Items[5].Count set value 64b
+data modify block -630 -20 2010 Items[6].Count set value 64b
+data modify block -630 -20 2010 Items[7].Count set value 64b
+data modify block -630 -20 2010 Items[8].Count set value 64b
+
+## Example Item: "Quickstep"
+data modify block -630 -20 2012 Items[0].Count set value 64b
+data modify block -630 -20 2012 Items[1].Count set value 64b
+data modify block -630 -20 2012 Items[2].Count set value 64b
+data modify block -630 -20 2012 Items[3].Count set value 64b
+data modify block -630 -20 2012 Items[4].Count set value 64b
+data modify block -630 -20 2012 Items[5].Count set value 64b
+data modify block -630 -20 2012 Items[6].Count set value 64b
+data modify block -630 -20 2012 Items[7].Count set value 64b
+data modify block -630 -20 2012 Items[8].Count set value 64b
+
+## Example Item: "Reckless Charge"
+data modify block -630 -20 2007 Items[0].Count set value 64b
+data modify block -630 -20 2007 Items[1].Count set value 64b
+data modify block -630 -20 2007 Items[2].Count set value 64b
+data modify block -630 -20 2007 Items[3].Count set value 64b
+data modify block -630 -20 2007 Items[4].Count set value 64b
+data modify block -630 -20 2007 Items[5].Count set value 64b
+data modify block -630 -20 2007 Items[6].Count set value 64b
+data modify block -630 -20 2007 Items[7].Count set value 64b
+data modify block -630 -20 2007 Items[8].Count set value 64b
+
+## Example Item: "Second Wind"
+data modify block -630 -20 2003 Items[0].Count set value 64b
+data modify block -630 -20 2003 Items[1].Count set value 64b
+data modify block -630 -20 2003 Items[2].Count set value 64b
+data modify block -630 -20 2003 Items[3].Count set value 64b
+data modify block -630 -20 2003 Items[4].Count set value 64b
+data modify block -630 -20 2003 Items[5].Count set value 64b
+data modify block -630 -20 2003 Items[6].Count set value 64b
+data modify block -630 -20 2003 Items[7].Count set value 64b
+data modify block -630 -20 2003 Items[8].Count set value 64b
+
+## Example Item: "Smash and Grab"
+data modify block -630 -20 2011 Items[0].Count set value 64b
+data modify block -630 -20 2011 Items[1].Count set value 64b
+data modify block -630 -20 2011 Items[2].Count set value 64b
+data modify block -630 -20 2011 Items[3].Count set value 64b
+data modify block -630 -20 2011 Items[4].Count set value 64b
+data modify block -630 -20 2011 Items[5].Count set value 64b
+data modify block -630 -20 2011 Items[6].Count set value 64b
+data modify block -630 -20 2011 Items[7].Count set value 64b
+data modify block -630 -20 2011 Items[8].Count set value 64b
+
+## Example Item: "Sneak"
+data modify block -630 -20 1992 Items[0].Count set value 64b
+data modify block -630 -20 1992 Items[1].Count set value 64b
+data modify block -630 -20 1992 Items[2].Count set value 64b
+data modify block -630 -20 1992 Items[3].Count set value 64b
+data modify block -630 -20 1992 Items[4].Count set value 64b
+data modify block -630 -20 1992 Items[5].Count set value 64b
+data modify block -630 -20 1992 Items[6].Count set value 64b
+data modify block -630 -20 1992 Items[7].Count set value 64b
+data modify block -630 -20 1992 Items[8].Count set value 64b
+
+## Example Item: "Sprint"
+data modify block -630 -20 2008 Items[0].Count set value 64b
+data modify block -630 -20 2008 Items[1].Count set value 64b
+data modify block -630 -20 2008 Items[2].Count set value 64b
+data modify block -630 -20 2008 Items[3].Count set value 64b
+data modify block -630 -20 2008 Items[4].Count set value 64b
+data modify block -630 -20 2008 Items[5].Count set value 64b
+data modify block -630 -20 2008 Items[6].Count set value 64b
+data modify block -630 -20 2008 Items[7].Count set value 64b
+data modify block -630 -20 2008 Items[8].Count set value 64b
+
+## Example Item: "Stability"
+data modify block -630 -20 1993 Items[0].Count set value 64b
+data modify block -630 -20 1993 Items[1].Count set value 64b
+data modify block -630 -20 1993 Items[2].Count set value 64b
+data modify block -630 -20 1993 Items[3].Count set value 64b
+data modify block -630 -20 1993 Items[4].Count set value 64b
+data modify block -630 -20 1993 Items[5].Count set value 64b
+data modify block -630 -20 1993 Items[6].Count set value 64b
+data modify block -630 -20 1993 Items[7].Count set value 64b
+data modify block -630 -20 1993 Items[8].Count set value 64b
+
+## Example Item: "Suit Up"
+data modify block -630 -20 2013 Items[0].Count set value 64b
+data modify block -630 -20 2013 Items[1].Count set value 64b
+data modify block -630 -20 2013 Items[2].Count set value 64b
+data modify block -630 -20 2013 Items[3].Count set value 64b
+data modify block -630 -20 2013 Items[4].Count set value 64b
+data modify block -630 -20 2013 Items[5].Count set value 64b
+data modify block -630 -20 2013 Items[6].Count set value 64b
+data modify block -630 -20 2013 Items[7].Count set value 64b
+data modify block -630 -20 2013 Items[8].Count set value 64b
+
+## Example Item: "Tread Lightly"
+data modify block -630 -20 1999 Items[0].Count set value 64b
+data modify block -630 -20 1999 Items[1].Count set value 64b
+data modify block -630 -20 1999 Items[2].Count set value 64b
+data modify block -630 -20 1999 Items[3].Count set value 64b
+data modify block -630 -20 1999 Items[4].Count set value 64b
+data modify block -630 -20 1999 Items[5].Count set value 64b
+data modify block -630 -20 1999 Items[6].Count set value 64b
+data modify block -630 -20 1999 Items[7].Count set value 64b
+data modify block -630 -20 1999 Items[8].Count set value 64b
+
+## Example Item: "Treasure Hunter"
+data modify block -630 -20 1994 Items[0].Count set value 64b
+data modify block -630 -20 1994 Items[1].Count set value 64b
+data modify block -630 -20 1994 Items[2].Count set value 64b
+data modify block -630 -20 1994 Items[3].Count set value 64b
+data modify block -630 -20 1994 Items[4].Count set value 64b
+data modify block -630 -20 1994 Items[5].Count set value 64b
+data modify block -630 -20 1994 Items[6].Count set value 64b
+data modify block -630 -20 1994 Items[7].Count set value 64b
+data modify block -630 -20 1994 Items[8].Count set value 64b
+
+# Category "Compass"
+## Example Item: "Compass Level Token"
+data modify block -557 109 1982 Items[0].Count set value 64b
+data modify block -557 109 1982 Items[1].Count set value 64b
+data modify block -557 109 1982 Items[2].Count set value 64b
+data modify block -557 109 1982 Items[3].Count set value 64b
+data modify block -557 109 1982 Items[4].Count set value 64b
+data modify block -557 109 1982 Items[5].Count set value 64b
+data modify block -557 109 1982 Items[6].Count set value 64b
+data modify block -557 109 1982 Items[7].Count set value 64b
+data modify block -557 109 1982 Items[8].Count set value 64b
+
+## Example Item: "Compass Level Token"
+data modify block -558 109 1982 Items[0].Count set value 64b
+data modify block -558 109 1982 Items[1].Count set value 64b
+data modify block -558 109 1982 Items[2].Count set value 64b
+data modify block -558 109 1982 Items[3].Count set value 64b
+data modify block -558 109 1982 Items[4].Count set value 64b
+data modify block -558 109 1982 Items[5].Count set value 64b
+data modify block -558 109 1982 Items[6].Count set value 64b
+data modify block -558 109 1982 Items[7].Count set value 64b
+data modify block -558 109 1982 Items[8].Count set value 64b
+
+## Example Item: "Compass Level Token"
+data modify block -559 109 1982 Items[0].Count set value 64b
+data modify block -559 109 1982 Items[1].Count set value 64b
+data modify block -559 109 1982 Items[2].Count set value 64b
+data modify block -559 109 1982 Items[3].Count set value 64b
+data modify block -559 109 1982 Items[4].Count set value 64b
+data modify block -559 109 1982 Items[5].Count set value 64b
+data modify block -559 109 1982 Items[6].Count set value 64b
+data modify block -559 109 1982 Items[7].Count set value 64b
+data modify block -559 109 1982 Items[8].Count set value 64b
+
+## Example Item: "Compass Level Token"
+data modify block -560 109 1982 Items[0].Count set value 64b
+data modify block -560 109 1982 Items[1].Count set value 64b
+data modify block -560 109 1982 Items[2].Count set value 64b
+data modify block -560 109 1982 Items[3].Count set value 64b
+data modify block -560 109 1982 Items[4].Count set value 64b
+data modify block -560 109 1982 Items[5].Count set value 64b
+data modify block -560 109 1982 Items[6].Count set value 64b
+data modify block -560 109 1982 Items[7].Count set value 64b
+data modify block -560 109 1982 Items[8].Count set value 64b
+
+## Example Item: "Compass Level Token"
+data modify block -561 109 1982 Items[0].Count set value 64b
+data modify block -561 109 1982 Items[1].Count set value 64b
+data modify block -561 109 1982 Items[2].Count set value 64b
+data modify block -561 109 1982 Items[3].Count set value 64b
+data modify block -561 109 1982 Items[4].Count set value 64b
+data modify block -561 109 1982 Items[5].Count set value 64b
+data modify block -561 109 1982 Items[6].Count set value 64b
+data modify block -561 109 1982 Items[7].Count set value 64b
+data modify block -561 109 1982 Items[8].Count set value 64b
+
+## Example Item: "Manual Compass"
+data modify block -549 106 1970 Items[0].Count set value 64b
+data modify block -549 106 1970 Items[1].Count set value 64b
+data modify block -549 106 1970 Items[2].Count set value 64b
+data modify block -549 106 1970 Items[3].Count set value 64b
+data modify block -549 106 1970 Items[4].Count set value 64b
+data modify block -549 106 1970 Items[5].Count set value 64b
+data modify block -549 106 1970 Items[6].Count set value 64b
+data modify block -549 106 1970 Items[7].Count set value 64b
+data modify block -549 106 1970 Items[8].Count set value 64b
+
+## Example Item: "Manual Compass"
+data modify block -549 106 1971 Items[0].Count set value 64b
+data modify block -549 106 1971 Items[1].Count set value 64b
+data modify block -549 106 1971 Items[2].Count set value 64b
+data modify block -549 106 1971 Items[3].Count set value 64b
+data modify block -549 106 1971 Items[4].Count set value 64b
+data modify block -549 106 1971 Items[5].Count set value 64b
+data modify block -549 106 1971 Items[6].Count set value 64b
+data modify block -549 106 1971 Items[7].Count set value 64b
+data modify block -549 106 1971 Items[8].Count set value 64b
+
+## Example Item: "Manual Compass"
+data modify block -549 106 1972 Items[0].Count set value 64b
+data modify block -549 106 1972 Items[1].Count set value 64b
+data modify block -549 106 1972 Items[2].Count set value 64b
+data modify block -549 106 1972 Items[3].Count set value 64b
+data modify block -549 106 1972 Items[4].Count set value 64b
+data modify block -549 106 1972 Items[5].Count set value 64b
+data modify block -549 106 1972 Items[6].Count set value 64b
+data modify block -549 106 1972 Items[7].Count set value 64b
+data modify block -549 106 1972 Items[8].Count set value 64b
+
+## Example Item: "Manual Compass"
+data modify block -549 106 1973 Items[0].Count set value 64b
+data modify block -549 106 1973 Items[1].Count set value 64b
+data modify block -549 106 1973 Items[2].Count set value 64b
+data modify block -549 106 1973 Items[3].Count set value 64b
+data modify block -549 106 1973 Items[4].Count set value 64b
+data modify block -549 106 1973 Items[5].Count set value 64b
+data modify block -549 106 1973 Items[6].Count set value 64b
+data modify block -549 106 1973 Items[7].Count set value 64b
+data modify block -549 106 1973 Items[8].Count set value 64b
+
+## Example Item: "Manual Compass"
+data modify block -549 106 1974 Items[0].Count set value 64b
+data modify block -549 106 1974 Items[1].Count set value 64b
+data modify block -549 106 1974 Items[2].Count set value 64b
+data modify block -549 106 1974 Items[3].Count set value 64b
+data modify block -549 106 1974 Items[4].Count set value 64b
+data modify block -549 106 1974 Items[5].Count set value 64b
+data modify block -549 106 1974 Items[6].Count set value 64b
+data modify block -549 106 1974 Items[7].Count set value 64b
+data modify block -549 106 1974 Items[8].Count set value 64b
+
+## Example Item: "Manual Compass"
+data modify block -549 106 1975 Items[0].Count set value 64b
+data modify block -549 106 1975 Items[1].Count set value 64b
+data modify block -549 106 1975 Items[2].Count set value 64b
+data modify block -549 106 1975 Items[3].Count set value 64b
+data modify block -549 106 1975 Items[4].Count set value 64b
+data modify block -549 106 1975 Items[5].Count set value 64b
+data modify block -549 106 1975 Items[6].Count set value 64b
+data modify block -549 106 1975 Items[7].Count set value 64b
+data modify block -549 106 1975 Items[8].Count set value 64b
+
+## Example Item: "Manual Compass"
+data modify block -549 106 1976 Items[0].Count set value 64b
+data modify block -549 106 1976 Items[1].Count set value 64b
+data modify block -549 106 1976 Items[2].Count set value 64b
+data modify block -549 106 1976 Items[3].Count set value 64b
+data modify block -549 106 1976 Items[4].Count set value 64b
+data modify block -549 106 1976 Items[5].Count set value 64b
+data modify block -549 106 1976 Items[6].Count set value 64b
+data modify block -549 106 1976 Items[7].Count set value 64b
+data modify block -549 106 1976 Items[8].Count set value 64b
+
+## Example Item: "Manual Compass"
+data modify block -549 106 1977 Items[0].Count set value 64b
+data modify block -549 106 1977 Items[1].Count set value 64b
+data modify block -549 106 1977 Items[2].Count set value 64b
+data modify block -549 106 1977 Items[3].Count set value 64b
+data modify block -549 106 1977 Items[4].Count set value 64b
+data modify block -549 106 1977 Items[5].Count set value 64b
+data modify block -549 106 1977 Items[6].Count set value 64b
+data modify block -549 106 1977 Items[7].Count set value 64b
+data modify block -549 106 1977 Items[8].Count set value 64b
+
+## Example Item: "Manual Compass"
+data modify block -549 106 1978 Items[0].Count set value 64b
+data modify block -549 106 1978 Items[1].Count set value 64b
+data modify block -549 106 1978 Items[2].Count set value 64b
+data modify block -549 106 1978 Items[3].Count set value 64b
+data modify block -549 106 1978 Items[4].Count set value 64b
+data modify block -549 106 1978 Items[5].Count set value 64b
+data modify block -549 106 1978 Items[6].Count set value 64b
+data modify block -549 106 1978 Items[7].Count set value 64b
+data modify block -549 106 1978 Items[8].Count set value 64b
+
+## Example Item: "Manual Compass"
+data modify block -549 106 1979 Items[0].Count set value 64b
+data modify block -549 106 1979 Items[1].Count set value 64b
+data modify block -549 106 1979 Items[2].Count set value 64b
+data modify block -549 106 1979 Items[3].Count set value 64b
+data modify block -549 106 1979 Items[4].Count set value 64b
+data modify block -549 106 1979 Items[5].Count set value 64b
+data modify block -549 106 1979 Items[6].Count set value 64b
+data modify block -549 106 1979 Items[7].Count set value 64b
+data modify block -549 106 1979 Items[8].Count set value 64b
+
+# Category "Ember"
+## Example Item: "Decked Out Frost Ember"
+data modify block -478 19 2009 Items[0].Count set value 64b
+data modify block -478 19 2009 Items[1].Count set value 64b
+data modify block -478 19 2009 Items[2].Count set value 64b
+data modify block -478 19 2009 Items[3].Count set value 64b
+data modify block -478 19 2009 Items[4].Count set value 64b
+data modify block -478 19 2009 Items[5].Count set value 64b
+data modify block -478 19 2009 Items[6].Count set value 64b
+data modify block -478 19 2009 Items[7].Count set value 64b
+data modify block -478 19 2009 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -484 53 1988 Items[0].Count set value 64b
+data modify block -484 53 1988 Items[1].Count set value 64b
+data modify block -484 53 1988 Items[2].Count set value 64b
+data modify block -484 53 1988 Items[3].Count set value 64b
+data modify block -484 53 1988 Items[4].Count set value 64b
+data modify block -484 53 1988 Items[5].Count set value 64b
+data modify block -484 53 1988 Items[6].Count set value 64b
+data modify block -484 53 1988 Items[7].Count set value 64b
+data modify block -484 53 1988 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -485 31 1962 Items[0].Count set value 64b
+data modify block -485 31 1962 Items[1].Count set value 64b
+data modify block -485 31 1962 Items[2].Count set value 64b
+data modify block -485 31 1962 Items[3].Count set value 64b
+data modify block -485 31 1962 Items[4].Count set value 64b
+data modify block -485 31 1962 Items[5].Count set value 64b
+data modify block -485 31 1962 Items[6].Count set value 64b
+data modify block -485 31 1962 Items[7].Count set value 64b
+data modify block -485 31 1962 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -489 11 2007 Items[0].Count set value 64b
+data modify block -489 11 2007 Items[1].Count set value 64b
+data modify block -489 11 2007 Items[2].Count set value 64b
+data modify block -489 11 2007 Items[3].Count set value 64b
+data modify block -489 11 2007 Items[4].Count set value 64b
+data modify block -489 11 2007 Items[5].Count set value 64b
+data modify block -489 11 2007 Items[6].Count set value 64b
+data modify block -489 11 2007 Items[7].Count set value 64b
+data modify block -489 11 2007 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -490 50 2016 Items[0].Count set value 64b
+data modify block -490 50 2016 Items[1].Count set value 64b
+data modify block -490 50 2016 Items[2].Count set value 64b
+data modify block -490 50 2016 Items[3].Count set value 64b
+data modify block -490 50 2016 Items[4].Count set value 64b
+data modify block -490 50 2016 Items[5].Count set value 64b
+data modify block -490 50 2016 Items[6].Count set value 64b
+data modify block -490 50 2016 Items[7].Count set value 64b
+data modify block -490 50 2016 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -496 15 1999 Items[0].Count set value 64b
+data modify block -496 15 1999 Items[1].Count set value 64b
+data modify block -496 15 1999 Items[2].Count set value 64b
+data modify block -496 15 1999 Items[3].Count set value 64b
+data modify block -496 15 1999 Items[4].Count set value 64b
+data modify block -496 15 1999 Items[5].Count set value 64b
+data modify block -496 15 1999 Items[6].Count set value 64b
+data modify block -496 15 1999 Items[7].Count set value 64b
+data modify block -496 15 1999 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -498 51 1980 Items[0].Count set value 64b
+data modify block -498 51 1980 Items[1].Count set value 64b
+data modify block -498 51 1980 Items[2].Count set value 64b
+data modify block -498 51 1980 Items[3].Count set value 64b
+data modify block -498 51 1980 Items[4].Count set value 64b
+data modify block -498 51 1980 Items[5].Count set value 64b
+data modify block -498 51 1980 Items[6].Count set value 64b
+data modify block -498 51 1980 Items[7].Count set value 64b
+data modify block -498 51 1980 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -501 16 1972 Items[0].Count set value 64b
+data modify block -501 16 1972 Items[1].Count set value 64b
+data modify block -501 16 1972 Items[2].Count set value 64b
+data modify block -501 16 1972 Items[3].Count set value 64b
+data modify block -501 16 1972 Items[4].Count set value 64b
+data modify block -501 16 1972 Items[5].Count set value 64b
+data modify block -501 16 1972 Items[6].Count set value 64b
+data modify block -501 16 1972 Items[7].Count set value 64b
+data modify block -501 16 1972 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -502 31 1975 Items[0].Count set value 64b
+data modify block -502 31 1975 Items[1].Count set value 64b
+data modify block -502 31 1975 Items[2].Count set value 64b
+data modify block -502 31 1975 Items[3].Count set value 64b
+data modify block -502 31 1975 Items[4].Count set value 64b
+data modify block -502 31 1975 Items[5].Count set value 64b
+data modify block -502 31 1975 Items[6].Count set value 64b
+data modify block -502 31 1975 Items[7].Count set value 64b
+data modify block -502 31 1975 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -508 9 1951 Items[0].Count set value 64b
+data modify block -508 9 1951 Items[1].Count set value 64b
+data modify block -508 9 1951 Items[2].Count set value 64b
+data modify block -508 9 1951 Items[3].Count set value 64b
+data modify block -508 9 1951 Items[4].Count set value 64b
+data modify block -508 9 1951 Items[5].Count set value 64b
+data modify block -508 9 1951 Items[6].Count set value 64b
+data modify block -508 9 1951 Items[7].Count set value 64b
+data modify block -508 9 1951 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -509 14 2033 Items[0].Count set value 64b
+data modify block -509 14 2033 Items[1].Count set value 64b
+data modify block -509 14 2033 Items[2].Count set value 64b
+data modify block -509 14 2033 Items[3].Count set value 64b
+data modify block -509 14 2033 Items[4].Count set value 64b
+data modify block -509 14 2033 Items[5].Count set value 64b
+data modify block -509 14 2033 Items[6].Count set value 64b
+data modify block -509 14 2033 Items[7].Count set value 64b
+data modify block -509 14 2033 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -513 51 1962 Items[0].Count set value 64b
+data modify block -513 51 1962 Items[1].Count set value 64b
+data modify block -513 51 1962 Items[2].Count set value 64b
+data modify block -513 51 1962 Items[3].Count set value 64b
+data modify block -513 51 1962 Items[4].Count set value 64b
+data modify block -513 51 1962 Items[5].Count set value 64b
+data modify block -513 51 1962 Items[6].Count set value 64b
+data modify block -513 51 1962 Items[7].Count set value 64b
+data modify block -513 51 1962 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -515 46 2031 Items[0].Count set value 64b
+data modify block -515 46 2031 Items[1].Count set value 64b
+data modify block -515 46 2031 Items[2].Count set value 64b
+data modify block -515 46 2031 Items[3].Count set value 64b
+data modify block -515 46 2031 Items[4].Count set value 64b
+data modify block -515 46 2031 Items[5].Count set value 64b
+data modify block -515 46 2031 Items[6].Count set value 64b
+data modify block -515 46 2031 Items[7].Count set value 64b
+data modify block -515 46 2031 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -518 2 2007 Items[0].Count set value 64b
+data modify block -518 2 2007 Items[1].Count set value 64b
+data modify block -518 2 2007 Items[2].Count set value 64b
+data modify block -518 2 2007 Items[3].Count set value 64b
+data modify block -518 2 2007 Items[4].Count set value 64b
+data modify block -518 2 2007 Items[5].Count set value 64b
+data modify block -518 2 2007 Items[6].Count set value 64b
+data modify block -518 2 2007 Items[7].Count set value 64b
+data modify block -518 2 2007 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -518 53 2011 Items[0].Count set value 64b
+data modify block -518 53 2011 Items[1].Count set value 64b
+data modify block -518 53 2011 Items[2].Count set value 64b
+data modify block -518 53 2011 Items[3].Count set value 64b
+data modify block -518 53 2011 Items[4].Count set value 64b
+data modify block -518 53 2011 Items[5].Count set value 64b
+data modify block -518 53 2011 Items[6].Count set value 64b
+data modify block -518 53 2011 Items[7].Count set value 64b
+data modify block -518 53 2011 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -518 53 2011 Items[0].Count set value 64b
+data modify block -518 53 2011 Items[1].Count set value 64b
+data modify block -518 53 2011 Items[2].Count set value 64b
+data modify block -518 53 2011 Items[3].Count set value 64b
+data modify block -518 53 2011 Items[4].Count set value 64b
+data modify block -518 53 2011 Items[5].Count set value 64b
+data modify block -518 53 2011 Items[6].Count set value 64b
+data modify block -518 53 2011 Items[7].Count set value 64b
+data modify block -518 53 2011 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -519 35 2002 Items[0].Count set value 64b
+data modify block -519 35 2002 Items[1].Count set value 64b
+data modify block -519 35 2002 Items[2].Count set value 64b
+data modify block -519 35 2002 Items[3].Count set value 64b
+data modify block -519 35 2002 Items[4].Count set value 64b
+data modify block -519 35 2002 Items[5].Count set value 64b
+data modify block -519 35 2002 Items[6].Count set value 64b
+data modify block -519 35 2002 Items[7].Count set value 64b
+data modify block -519 35 2002 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -521 35 1981 Items[0].Count set value 64b
+data modify block -521 35 1981 Items[1].Count set value 64b
+data modify block -521 35 1981 Items[2].Count set value 64b
+data modify block -521 35 1981 Items[3].Count set value 64b
+data modify block -521 35 1981 Items[4].Count set value 64b
+data modify block -521 35 1981 Items[5].Count set value 64b
+data modify block -521 35 1981 Items[6].Count set value 64b
+data modify block -521 35 1981 Items[7].Count set value 64b
+data modify block -521 35 1981 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -526 12 1941 Items[0].Count set value 64b
+data modify block -526 12 1941 Items[1].Count set value 64b
+data modify block -526 12 1941 Items[2].Count set value 64b
+data modify block -526 12 1941 Items[3].Count set value 64b
+data modify block -526 12 1941 Items[4].Count set value 64b
+data modify block -526 12 1941 Items[5].Count set value 64b
+data modify block -526 12 1941 Items[6].Count set value 64b
+data modify block -526 12 1941 Items[7].Count set value 64b
+data modify block -526 12 1941 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -527 51 1974 Items[0].Count set value 64b
+data modify block -527 51 1974 Items[1].Count set value 64b
+data modify block -527 51 1974 Items[2].Count set value 64b
+data modify block -527 51 1974 Items[3].Count set value 64b
+data modify block -527 51 1974 Items[4].Count set value 64b
+data modify block -527 51 1974 Items[5].Count set value 64b
+data modify block -527 51 1974 Items[6].Count set value 64b
+data modify block -527 51 1974 Items[7].Count set value 64b
+data modify block -527 51 1974 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -528 12 2032 Items[0].Count set value 64b
+data modify block -528 12 2032 Items[1].Count set value 64b
+data modify block -528 12 2032 Items[2].Count set value 64b
+data modify block -528 12 2032 Items[3].Count set value 64b
+data modify block -528 12 2032 Items[4].Count set value 64b
+data modify block -528 12 2032 Items[5].Count set value 64b
+data modify block -528 12 2032 Items[6].Count set value 64b
+data modify block -528 12 2032 Items[7].Count set value 64b
+data modify block -528 12 2032 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -531 16 1989 Items[0].Count set value 64b
+data modify block -531 16 1989 Items[1].Count set value 64b
+data modify block -531 16 1989 Items[2].Count set value 64b
+data modify block -531 16 1989 Items[3].Count set value 64b
+data modify block -531 16 1989 Items[4].Count set value 64b
+data modify block -531 16 1989 Items[5].Count set value 64b
+data modify block -531 16 1989 Items[6].Count set value 64b
+data modify block -531 16 1989 Items[7].Count set value 64b
+data modify block -531 16 1989 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -533 44 2024 Items[0].Count set value 64b
+data modify block -533 44 2024 Items[1].Count set value 64b
+data modify block -533 44 2024 Items[2].Count set value 64b
+data modify block -533 44 2024 Items[3].Count set value 64b
+data modify block -533 44 2024 Items[4].Count set value 64b
+data modify block -533 44 2024 Items[5].Count set value 64b
+data modify block -533 44 2024 Items[6].Count set value 64b
+data modify block -533 44 2024 Items[7].Count set value 64b
+data modify block -533 44 2024 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -537 45 1948 Items[0].Count set value 64b
+data modify block -537 45 1948 Items[1].Count set value 64b
+data modify block -537 45 1948 Items[2].Count set value 64b
+data modify block -537 45 1948 Items[3].Count set value 64b
+data modify block -537 45 1948 Items[4].Count set value 64b
+data modify block -537 45 1948 Items[5].Count set value 64b
+data modify block -537 45 1948 Items[6].Count set value 64b
+data modify block -537 45 1948 Items[7].Count set value 64b
+data modify block -537 45 1948 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -542 11 1998 Items[0].Count set value 64b
+data modify block -542 11 1998 Items[1].Count set value 64b
+data modify block -542 11 1998 Items[2].Count set value 64b
+data modify block -542 11 1998 Items[3].Count set value 64b
+data modify block -542 11 1998 Items[4].Count set value 64b
+data modify block -542 11 1998 Items[5].Count set value 64b
+data modify block -542 11 1998 Items[6].Count set value 64b
+data modify block -542 11 1998 Items[7].Count set value 64b
+data modify block -542 11 1998 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -545 51 2008 Items[0].Count set value 64b
+data modify block -545 51 2008 Items[1].Count set value 64b
+data modify block -545 51 2008 Items[2].Count set value 64b
+data modify block -545 51 2008 Items[3].Count set value 64b
+data modify block -545 51 2008 Items[4].Count set value 64b
+data modify block -545 51 2008 Items[5].Count set value 64b
+data modify block -545 51 2008 Items[6].Count set value 64b
+data modify block -545 51 2008 Items[7].Count set value 64b
+data modify block -545 51 2008 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -548 11 1976 Items[0].Count set value 64b
+data modify block -548 11 1976 Items[1].Count set value 64b
+data modify block -548 11 1976 Items[2].Count set value 64b
+data modify block -548 11 1976 Items[3].Count set value 64b
+data modify block -548 11 1976 Items[4].Count set value 64b
+data modify block -548 11 1976 Items[5].Count set value 64b
+data modify block -548 11 1976 Items[6].Count set value 64b
+data modify block -548 11 1976 Items[7].Count set value 64b
+data modify block -548 11 1976 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -553 10 2037 Items[0].Count set value 64b
+data modify block -553 10 2037 Items[1].Count set value 64b
+data modify block -553 10 2037 Items[2].Count set value 64b
+data modify block -553 10 2037 Items[3].Count set value 64b
+data modify block -553 10 2037 Items[4].Count set value 64b
+data modify block -553 10 2037 Items[5].Count set value 64b
+data modify block -553 10 2037 Items[6].Count set value 64b
+data modify block -553 10 2037 Items[7].Count set value 64b
+data modify block -553 10 2037 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -554 51 2008 Items[0].Count set value 64b
+data modify block -554 51 2008 Items[1].Count set value 64b
+data modify block -554 51 2008 Items[2].Count set value 64b
+data modify block -554 51 2008 Items[3].Count set value 64b
+data modify block -554 51 2008 Items[4].Count set value 64b
+data modify block -554 51 2008 Items[5].Count set value 64b
+data modify block -554 51 2008 Items[6].Count set value 64b
+data modify block -554 51 2008 Items[7].Count set value 64b
+data modify block -554 51 2008 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -558 45 1976 Items[0].Count set value 64b
+data modify block -558 45 1976 Items[1].Count set value 64b
+data modify block -558 45 1976 Items[2].Count set value 64b
+data modify block -558 45 1976 Items[3].Count set value 64b
+data modify block -558 45 1976 Items[4].Count set value 64b
+data modify block -558 45 1976 Items[5].Count set value 64b
+data modify block -558 45 1976 Items[6].Count set value 64b
+data modify block -558 45 1976 Items[7].Count set value 64b
+data modify block -558 45 1976 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -558 46 2022 Items[0].Count set value 64b
+data modify block -558 46 2022 Items[1].Count set value 64b
+data modify block -558 46 2022 Items[2].Count set value 64b
+data modify block -558 46 2022 Items[3].Count set value 64b
+data modify block -558 46 2022 Items[4].Count set value 64b
+data modify block -558 46 2022 Items[5].Count set value 64b
+data modify block -558 46 2022 Items[6].Count set value 64b
+data modify block -558 46 2022 Items[7].Count set value 64b
+data modify block -558 46 2022 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -560 47 1942 Items[0].Count set value 64b
+data modify block -560 47 1942 Items[1].Count set value 64b
+data modify block -560 47 1942 Items[2].Count set value 64b
+data modify block -560 47 1942 Items[3].Count set value 64b
+data modify block -560 47 1942 Items[4].Count set value 64b
+data modify block -560 47 1942 Items[5].Count set value 64b
+data modify block -560 47 1942 Items[6].Count set value 64b
+data modify block -560 47 1942 Items[7].Count set value 64b
+data modify block -560 47 1942 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -565 36 1999 Items[0].Count set value 64b
+data modify block -565 36 1999 Items[1].Count set value 64b
+data modify block -565 36 1999 Items[2].Count set value 64b
+data modify block -565 36 1999 Items[3].Count set value 64b
+data modify block -565 36 1999 Items[4].Count set value 64b
+data modify block -565 36 1999 Items[5].Count set value 64b
+data modify block -565 36 1999 Items[6].Count set value 64b
+data modify block -565 36 1999 Items[7].Count set value 64b
+data modify block -565 36 1999 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -569 8 1964 Items[0].Count set value 64b
+data modify block -569 8 1964 Items[1].Count set value 64b
+data modify block -569 8 1964 Items[2].Count set value 64b
+data modify block -569 8 1964 Items[3].Count set value 64b
+data modify block -569 8 1964 Items[4].Count set value 64b
+data modify block -569 8 1964 Items[5].Count set value 64b
+data modify block -569 8 1964 Items[6].Count set value 64b
+data modify block -569 8 1964 Items[7].Count set value 64b
+data modify block -569 8 1964 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -573 11 2007 Items[0].Count set value 64b
+data modify block -573 11 2007 Items[1].Count set value 64b
+data modify block -573 11 2007 Items[2].Count set value 64b
+data modify block -573 11 2007 Items[3].Count set value 64b
+data modify block -573 11 2007 Items[4].Count set value 64b
+data modify block -573 11 2007 Items[5].Count set value 64b
+data modify block -573 11 2007 Items[6].Count set value 64b
+data modify block -573 11 2007 Items[7].Count set value 64b
+data modify block -573 11 2007 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -573 36 1998 Items[0].Count set value 64b
+data modify block -573 36 1998 Items[1].Count set value 64b
+data modify block -573 36 1998 Items[2].Count set value 64b
+data modify block -573 36 1998 Items[3].Count set value 64b
+data modify block -573 36 1998 Items[4].Count set value 64b
+data modify block -573 36 1998 Items[5].Count set value 64b
+data modify block -573 36 1998 Items[6].Count set value 64b
+data modify block -573 36 1998 Items[7].Count set value 64b
+data modify block -573 36 1998 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -579 -37 1835 Items[0].Count set value 64b
+data modify block -579 -37 1835 Items[1].Count set value 64b
+data modify block -579 -37 1835 Items[2].Count set value 64b
+data modify block -579 -37 1835 Items[3].Count set value 64b
+data modify block -579 -37 1835 Items[4].Count set value 64b
+data modify block -579 -37 1835 Items[5].Count set value 64b
+data modify block -579 -37 1835 Items[6].Count set value 64b
+data modify block -579 -37 1835 Items[7].Count set value 64b
+data modify block -579 -37 1835 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -582 13 1934 Items[0].Count set value 64b
+data modify block -582 13 1934 Items[1].Count set value 64b
+data modify block -582 13 1934 Items[2].Count set value 64b
+data modify block -582 13 1934 Items[3].Count set value 64b
+data modify block -582 13 1934 Items[4].Count set value 64b
+data modify block -582 13 1934 Items[5].Count set value 64b
+data modify block -582 13 1934 Items[6].Count set value 64b
+data modify block -582 13 1934 Items[7].Count set value 64b
+data modify block -582 13 1934 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -582 13 1935 Items[0].Count set value 64b
+data modify block -582 13 1935 Items[1].Count set value 64b
+data modify block -582 13 1935 Items[2].Count set value 64b
+data modify block -582 13 1935 Items[3].Count set value 64b
+data modify block -582 13 1935 Items[4].Count set value 64b
+data modify block -582 13 1935 Items[5].Count set value 64b
+data modify block -582 13 1935 Items[6].Count set value 64b
+data modify block -582 13 1935 Items[7].Count set value 64b
+data modify block -582 13 1935 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -582 13 1936 Items[0].Count set value 64b
+data modify block -582 13 1936 Items[1].Count set value 64b
+data modify block -582 13 1936 Items[2].Count set value 64b
+data modify block -582 13 1936 Items[3].Count set value 64b
+data modify block -582 13 1936 Items[4].Count set value 64b
+data modify block -582 13 1936 Items[5].Count set value 64b
+data modify block -582 13 1936 Items[6].Count set value 64b
+data modify block -582 13 1936 Items[7].Count set value 64b
+data modify block -582 13 1936 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -582 13 1937 Items[0].Count set value 64b
+data modify block -582 13 1937 Items[1].Count set value 64b
+data modify block -582 13 1937 Items[2].Count set value 64b
+data modify block -582 13 1937 Items[3].Count set value 64b
+data modify block -582 13 1937 Items[4].Count set value 64b
+data modify block -582 13 1937 Items[5].Count set value 64b
+data modify block -582 13 1937 Items[6].Count set value 64b
+data modify block -582 13 1937 Items[7].Count set value 64b
+data modify block -582 13 1937 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -582 9 1955 Items[0].Count set value 64b
+data modify block -582 9 1955 Items[1].Count set value 64b
+data modify block -582 9 1955 Items[2].Count set value 64b
+data modify block -582 9 1955 Items[3].Count set value 64b
+data modify block -582 9 1955 Items[4].Count set value 64b
+data modify block -582 9 1955 Items[5].Count set value 64b
+data modify block -582 9 1955 Items[6].Count set value 64b
+data modify block -582 9 1955 Items[7].Count set value 64b
+data modify block -582 9 1955 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -583 45 2013 Items[0].Count set value 64b
+data modify block -583 45 2013 Items[1].Count set value 64b
+data modify block -583 45 2013 Items[2].Count set value 64b
+data modify block -583 45 2013 Items[3].Count set value 64b
+data modify block -583 45 2013 Items[4].Count set value 64b
+data modify block -583 45 2013 Items[5].Count set value 64b
+data modify block -583 45 2013 Items[6].Count set value 64b
+data modify block -583 45 2013 Items[7].Count set value 64b
+data modify block -583 45 2013 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -584 -17 1927 Items[0].Count set value 64b
+data modify block -584 -17 1927 Items[1].Count set value 64b
+data modify block -584 -17 1927 Items[2].Count set value 64b
+data modify block -584 -17 1927 Items[3].Count set value 64b
+data modify block -584 -17 1927 Items[4].Count set value 64b
+data modify block -584 -17 1927 Items[5].Count set value 64b
+data modify block -584 -17 1927 Items[6].Count set value 64b
+data modify block -584 -17 1927 Items[7].Count set value 64b
+data modify block -584 -17 1927 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -584 13 1934 Items[0].Count set value 64b
+data modify block -584 13 1934 Items[1].Count set value 64b
+data modify block -584 13 1934 Items[2].Count set value 64b
+data modify block -584 13 1934 Items[3].Count set value 64b
+data modify block -584 13 1934 Items[4].Count set value 64b
+data modify block -584 13 1934 Items[5].Count set value 64b
+data modify block -584 13 1934 Items[6].Count set value 64b
+data modify block -584 13 1934 Items[7].Count set value 64b
+data modify block -584 13 1934 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -584 13 1935 Items[0].Count set value 64b
+data modify block -584 13 1935 Items[1].Count set value 64b
+data modify block -584 13 1935 Items[2].Count set value 64b
+data modify block -584 13 1935 Items[3].Count set value 64b
+data modify block -584 13 1935 Items[4].Count set value 64b
+data modify block -584 13 1935 Items[5].Count set value 64b
+data modify block -584 13 1935 Items[6].Count set value 64b
+data modify block -584 13 1935 Items[7].Count set value 64b
+data modify block -584 13 1935 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -584 13 1936 Items[0].Count set value 64b
+data modify block -584 13 1936 Items[1].Count set value 64b
+data modify block -584 13 1936 Items[2].Count set value 64b
+data modify block -584 13 1936 Items[3].Count set value 64b
+data modify block -584 13 1936 Items[4].Count set value 64b
+data modify block -584 13 1936 Items[5].Count set value 64b
+data modify block -584 13 1936 Items[6].Count set value 64b
+data modify block -584 13 1936 Items[7].Count set value 64b
+data modify block -584 13 1936 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -584 13 1937 Items[0].Count set value 64b
+data modify block -584 13 1937 Items[1].Count set value 64b
+data modify block -584 13 1937 Items[2].Count set value 64b
+data modify block -584 13 1937 Items[3].Count set value 64b
+data modify block -584 13 1937 Items[4].Count set value 64b
+data modify block -584 13 1937 Items[5].Count set value 64b
+data modify block -584 13 1937 Items[6].Count set value 64b
+data modify block -584 13 1937 Items[7].Count set value 64b
+data modify block -584 13 1937 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -585 -9 1920 Items[0].Count set value 64b
+data modify block -585 -9 1920 Items[1].Count set value 64b
+data modify block -585 -9 1920 Items[2].Count set value 64b
+data modify block -585 -9 1920 Items[3].Count set value 64b
+data modify block -585 -9 1920 Items[4].Count set value 64b
+data modify block -585 -9 1920 Items[5].Count set value 64b
+data modify block -585 -9 1920 Items[6].Count set value 64b
+data modify block -585 -9 1920 Items[7].Count set value 64b
+data modify block -585 -9 1920 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -586 1 1888 Items[0].Count set value 64b
+data modify block -586 1 1888 Items[1].Count set value 64b
+data modify block -586 1 1888 Items[2].Count set value 64b
+data modify block -586 1 1888 Items[3].Count set value 64b
+data modify block -586 1 1888 Items[4].Count set value 64b
+data modify block -586 1 1888 Items[5].Count set value 64b
+data modify block -586 1 1888 Items[6].Count set value 64b
+data modify block -586 1 1888 Items[7].Count set value 64b
+data modify block -586 1 1888 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -587 52 1951 Items[0].Count set value 64b
+data modify block -587 52 1951 Items[1].Count set value 64b
+data modify block -587 52 1951 Items[2].Count set value 64b
+data modify block -587 52 1951 Items[3].Count set value 64b
+data modify block -587 52 1951 Items[4].Count set value 64b
+data modify block -587 52 1951 Items[5].Count set value 64b
+data modify block -587 52 1951 Items[6].Count set value 64b
+data modify block -587 52 1951 Items[7].Count set value 64b
+data modify block -587 52 1951 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -589 11 2032 Items[0].Count set value 64b
+data modify block -589 11 2032 Items[1].Count set value 64b
+data modify block -589 11 2032 Items[2].Count set value 64b
+data modify block -589 11 2032 Items[3].Count set value 64b
+data modify block -589 11 2032 Items[4].Count set value 64b
+data modify block -589 11 2032 Items[5].Count set value 64b
+data modify block -589 11 2032 Items[6].Count set value 64b
+data modify block -589 11 2032 Items[7].Count set value 64b
+data modify block -589 11 2032 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -589 46 1978 Items[0].Count set value 64b
+data modify block -589 46 1978 Items[1].Count set value 64b
+data modify block -589 46 1978 Items[2].Count set value 64b
+data modify block -589 46 1978 Items[3].Count set value 64b
+data modify block -589 46 1978 Items[4].Count set value 64b
+data modify block -589 46 1978 Items[5].Count set value 64b
+data modify block -589 46 1978 Items[6].Count set value 64b
+data modify block -589 46 1978 Items[7].Count set value 64b
+data modify block -589 46 1978 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -591 1 1901 Items[0].Count set value 64b
+data modify block -591 1 1901 Items[1].Count set value 64b
+data modify block -591 1 1901 Items[2].Count set value 64b
+data modify block -591 1 1901 Items[3].Count set value 64b
+data modify block -591 1 1901 Items[4].Count set value 64b
+data modify block -591 1 1901 Items[5].Count set value 64b
+data modify block -591 1 1901 Items[6].Count set value 64b
+data modify block -591 1 1901 Items[7].Count set value 64b
+data modify block -591 1 1901 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -598 11 1989 Items[0].Count set value 64b
+data modify block -598 11 1989 Items[1].Count set value 64b
+data modify block -598 11 1989 Items[2].Count set value 64b
+data modify block -598 11 1989 Items[3].Count set value 64b
+data modify block -598 11 1989 Items[4].Count set value 64b
+data modify block -598 11 1989 Items[5].Count set value 64b
+data modify block -598 11 1989 Items[6].Count set value 64b
+data modify block -598 11 1989 Items[7].Count set value 64b
+data modify block -598 11 1989 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -599 12 2009 Items[0].Count set value 64b
+data modify block -599 12 2009 Items[1].Count set value 64b
+data modify block -599 12 2009 Items[2].Count set value 64b
+data modify block -599 12 2009 Items[3].Count set value 64b
+data modify block -599 12 2009 Items[4].Count set value 64b
+data modify block -599 12 2009 Items[5].Count set value 64b
+data modify block -599 12 2009 Items[6].Count set value 64b
+data modify block -599 12 2009 Items[7].Count set value 64b
+data modify block -599 12 2009 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -602 -9 1885 Items[0].Count set value 64b
+data modify block -602 -9 1885 Items[1].Count set value 64b
+data modify block -602 -9 1885 Items[2].Count set value 64b
+data modify block -602 -9 1885 Items[3].Count set value 64b
+data modify block -602 -9 1885 Items[4].Count set value 64b
+data modify block -602 -9 1885 Items[5].Count set value 64b
+data modify block -602 -9 1885 Items[6].Count set value 64b
+data modify block -602 -9 1885 Items[7].Count set value 64b
+data modify block -602 -9 1885 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -606 1 1921 Items[0].Count set value 64b
+data modify block -606 1 1921 Items[1].Count set value 64b
+data modify block -606 1 1921 Items[2].Count set value 64b
+data modify block -606 1 1921 Items[3].Count set value 64b
+data modify block -606 1 1921 Items[4].Count set value 64b
+data modify block -606 1 1921 Items[5].Count set value 64b
+data modify block -606 1 1921 Items[6].Count set value 64b
+data modify block -606 1 1921 Items[7].Count set value 64b
+data modify block -606 1 1921 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -606 43 2023 Items[0].Count set value 64b
+data modify block -606 43 2023 Items[1].Count set value 64b
+data modify block -606 43 2023 Items[2].Count set value 64b
+data modify block -606 43 2023 Items[3].Count set value 64b
+data modify block -606 43 2023 Items[4].Count set value 64b
+data modify block -606 43 2023 Items[5].Count set value 64b
+data modify block -606 43 2023 Items[6].Count set value 64b
+data modify block -606 43 2023 Items[7].Count set value 64b
+data modify block -606 43 2023 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -609 -19 1919 Items[0].Count set value 64b
+data modify block -609 -19 1919 Items[1].Count set value 64b
+data modify block -609 -19 1919 Items[2].Count set value 64b
+data modify block -609 -19 1919 Items[3].Count set value 64b
+data modify block -609 -19 1919 Items[4].Count set value 64b
+data modify block -609 -19 1919 Items[5].Count set value 64b
+data modify block -609 -19 1919 Items[6].Count set value 64b
+data modify block -609 -19 1919 Items[7].Count set value 64b
+data modify block -609 -19 1919 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -619 43 2026 Items[0].Count set value 64b
+data modify block -619 43 2026 Items[1].Count set value 64b
+data modify block -619 43 2026 Items[2].Count set value 64b
+data modify block -619 43 2026 Items[3].Count set value 64b
+data modify block -619 43 2026 Items[4].Count set value 64b
+data modify block -619 43 2026 Items[5].Count set value 64b
+data modify block -619 43 2026 Items[6].Count set value 64b
+data modify block -619 43 2026 Items[7].Count set value 64b
+data modify block -619 43 2026 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -623 -9 1924 Items[0].Count set value 64b
+data modify block -623 -9 1924 Items[1].Count set value 64b
+data modify block -623 -9 1924 Items[2].Count set value 64b
+data modify block -623 -9 1924 Items[3].Count set value 64b
+data modify block -623 -9 1924 Items[4].Count set value 64b
+data modify block -623 -9 1924 Items[5].Count set value 64b
+data modify block -623 -9 1924 Items[6].Count set value 64b
+data modify block -623 -9 1924 Items[7].Count set value 64b
+data modify block -623 -9 1924 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -628 1 1921 Items[0].Count set value 64b
+data modify block -628 1 1921 Items[1].Count set value 64b
+data modify block -628 1 1921 Items[2].Count set value 64b
+data modify block -628 1 1921 Items[3].Count set value 64b
+data modify block -628 1 1921 Items[4].Count set value 64b
+data modify block -628 1 1921 Items[5].Count set value 64b
+data modify block -628 1 1921 Items[6].Count set value 64b
+data modify block -628 1 1921 Items[7].Count set value 64b
+data modify block -628 1 1921 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1952 Items[0].Count set value 64b
+data modify block -633 -20 1952 Items[1].Count set value 64b
+data modify block -633 -20 1952 Items[2].Count set value 64b
+data modify block -633 -20 1952 Items[3].Count set value 64b
+data modify block -633 -20 1952 Items[4].Count set value 64b
+data modify block -633 -20 1952 Items[5].Count set value 64b
+data modify block -633 -20 1952 Items[6].Count set value 64b
+data modify block -633 -20 1952 Items[7].Count set value 64b
+data modify block -633 -20 1952 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1953 Items[0].Count set value 64b
+data modify block -633 -20 1953 Items[1].Count set value 64b
+data modify block -633 -20 1953 Items[2].Count set value 64b
+data modify block -633 -20 1953 Items[3].Count set value 64b
+data modify block -633 -20 1953 Items[4].Count set value 64b
+data modify block -633 -20 1953 Items[5].Count set value 64b
+data modify block -633 -20 1953 Items[6].Count set value 64b
+data modify block -633 -20 1953 Items[7].Count set value 64b
+data modify block -633 -20 1953 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1954 Items[0].Count set value 64b
+data modify block -633 -20 1954 Items[1].Count set value 64b
+data modify block -633 -20 1954 Items[2].Count set value 64b
+data modify block -633 -20 1954 Items[3].Count set value 64b
+data modify block -633 -20 1954 Items[4].Count set value 64b
+data modify block -633 -20 1954 Items[5].Count set value 64b
+data modify block -633 -20 1954 Items[6].Count set value 64b
+data modify block -633 -20 1954 Items[7].Count set value 64b
+data modify block -633 -20 1954 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1955 Items[0].Count set value 64b
+data modify block -633 -20 1955 Items[1].Count set value 64b
+data modify block -633 -20 1955 Items[2].Count set value 64b
+data modify block -633 -20 1955 Items[3].Count set value 64b
+data modify block -633 -20 1955 Items[4].Count set value 64b
+data modify block -633 -20 1955 Items[5].Count set value 64b
+data modify block -633 -20 1955 Items[6].Count set value 64b
+data modify block -633 -20 1955 Items[7].Count set value 64b
+data modify block -633 -20 1955 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1956 Items[0].Count set value 64b
+data modify block -633 -20 1956 Items[1].Count set value 64b
+data modify block -633 -20 1956 Items[2].Count set value 64b
+data modify block -633 -20 1956 Items[3].Count set value 64b
+data modify block -633 -20 1956 Items[4].Count set value 64b
+data modify block -633 -20 1956 Items[5].Count set value 64b
+data modify block -633 -20 1956 Items[6].Count set value 64b
+data modify block -633 -20 1956 Items[7].Count set value 64b
+data modify block -633 -20 1956 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1957 Items[0].Count set value 64b
+data modify block -633 -20 1957 Items[1].Count set value 64b
+data modify block -633 -20 1957 Items[2].Count set value 64b
+data modify block -633 -20 1957 Items[3].Count set value 64b
+data modify block -633 -20 1957 Items[4].Count set value 64b
+data modify block -633 -20 1957 Items[5].Count set value 64b
+data modify block -633 -20 1957 Items[6].Count set value 64b
+data modify block -633 -20 1957 Items[7].Count set value 64b
+data modify block -633 -20 1957 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1958 Items[0].Count set value 64b
+data modify block -633 -20 1958 Items[1].Count set value 64b
+data modify block -633 -20 1958 Items[2].Count set value 64b
+data modify block -633 -20 1958 Items[3].Count set value 64b
+data modify block -633 -20 1958 Items[4].Count set value 64b
+data modify block -633 -20 1958 Items[5].Count set value 64b
+data modify block -633 -20 1958 Items[6].Count set value 64b
+data modify block -633 -20 1958 Items[7].Count set value 64b
+data modify block -633 -20 1958 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1959 Items[0].Count set value 64b
+data modify block -633 -20 1959 Items[1].Count set value 64b
+data modify block -633 -20 1959 Items[2].Count set value 64b
+data modify block -633 -20 1959 Items[3].Count set value 64b
+data modify block -633 -20 1959 Items[4].Count set value 64b
+data modify block -633 -20 1959 Items[5].Count set value 64b
+data modify block -633 -20 1959 Items[6].Count set value 64b
+data modify block -633 -20 1959 Items[7].Count set value 64b
+data modify block -633 -20 1959 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1960 Items[0].Count set value 64b
+data modify block -633 -20 1960 Items[1].Count set value 64b
+data modify block -633 -20 1960 Items[2].Count set value 64b
+data modify block -633 -20 1960 Items[3].Count set value 64b
+data modify block -633 -20 1960 Items[4].Count set value 64b
+data modify block -633 -20 1960 Items[5].Count set value 64b
+data modify block -633 -20 1960 Items[6].Count set value 64b
+data modify block -633 -20 1960 Items[7].Count set value 64b
+data modify block -633 -20 1960 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1961 Items[0].Count set value 64b
+data modify block -633 -20 1961 Items[1].Count set value 64b
+data modify block -633 -20 1961 Items[2].Count set value 64b
+data modify block -633 -20 1961 Items[3].Count set value 64b
+data modify block -633 -20 1961 Items[4].Count set value 64b
+data modify block -633 -20 1961 Items[5].Count set value 64b
+data modify block -633 -20 1961 Items[6].Count set value 64b
+data modify block -633 -20 1961 Items[7].Count set value 64b
+data modify block -633 -20 1961 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1962 Items[0].Count set value 64b
+data modify block -633 -20 1962 Items[1].Count set value 64b
+data modify block -633 -20 1962 Items[2].Count set value 64b
+data modify block -633 -20 1962 Items[3].Count set value 64b
+data modify block -633 -20 1962 Items[4].Count set value 64b
+data modify block -633 -20 1962 Items[5].Count set value 64b
+data modify block -633 -20 1962 Items[6].Count set value 64b
+data modify block -633 -20 1962 Items[7].Count set value 64b
+data modify block -633 -20 1962 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1963 Items[0].Count set value 64b
+data modify block -633 -20 1963 Items[1].Count set value 64b
+data modify block -633 -20 1963 Items[2].Count set value 64b
+data modify block -633 -20 1963 Items[3].Count set value 64b
+data modify block -633 -20 1963 Items[4].Count set value 64b
+data modify block -633 -20 1963 Items[5].Count set value 64b
+data modify block -633 -20 1963 Items[6].Count set value 64b
+data modify block -633 -20 1963 Items[7].Count set value 64b
+data modify block -633 -20 1963 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1964 Items[0].Count set value 64b
+data modify block -633 -20 1964 Items[1].Count set value 64b
+data modify block -633 -20 1964 Items[2].Count set value 64b
+data modify block -633 -20 1964 Items[3].Count set value 64b
+data modify block -633 -20 1964 Items[4].Count set value 64b
+data modify block -633 -20 1964 Items[5].Count set value 64b
+data modify block -633 -20 1964 Items[6].Count set value 64b
+data modify block -633 -20 1964 Items[7].Count set value 64b
+data modify block -633 -20 1964 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1965 Items[0].Count set value 64b
+data modify block -633 -20 1965 Items[1].Count set value 64b
+data modify block -633 -20 1965 Items[2].Count set value 64b
+data modify block -633 -20 1965 Items[3].Count set value 64b
+data modify block -633 -20 1965 Items[4].Count set value 64b
+data modify block -633 -20 1965 Items[5].Count set value 64b
+data modify block -633 -20 1965 Items[6].Count set value 64b
+data modify block -633 -20 1965 Items[7].Count set value 64b
+data modify block -633 -20 1965 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1966 Items[0].Count set value 64b
+data modify block -633 -20 1966 Items[1].Count set value 64b
+data modify block -633 -20 1966 Items[2].Count set value 64b
+data modify block -633 -20 1966 Items[3].Count set value 64b
+data modify block -633 -20 1966 Items[4].Count set value 64b
+data modify block -633 -20 1966 Items[5].Count set value 64b
+data modify block -633 -20 1966 Items[6].Count set value 64b
+data modify block -633 -20 1966 Items[7].Count set value 64b
+data modify block -633 -20 1966 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1967 Items[0].Count set value 64b
+data modify block -633 -20 1967 Items[1].Count set value 64b
+data modify block -633 -20 1967 Items[2].Count set value 64b
+data modify block -633 -20 1967 Items[3].Count set value 64b
+data modify block -633 -20 1967 Items[4].Count set value 64b
+data modify block -633 -20 1967 Items[5].Count set value 64b
+data modify block -633 -20 1967 Items[6].Count set value 64b
+data modify block -633 -20 1967 Items[7].Count set value 64b
+data modify block -633 -20 1967 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1968 Items[0].Count set value 64b
+data modify block -633 -20 1968 Items[1].Count set value 64b
+data modify block -633 -20 1968 Items[2].Count set value 64b
+data modify block -633 -20 1968 Items[3].Count set value 64b
+data modify block -633 -20 1968 Items[4].Count set value 64b
+data modify block -633 -20 1968 Items[5].Count set value 64b
+data modify block -633 -20 1968 Items[6].Count set value 64b
+data modify block -633 -20 1968 Items[7].Count set value 64b
+data modify block -633 -20 1968 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1969 Items[0].Count set value 64b
+data modify block -633 -20 1969 Items[1].Count set value 64b
+data modify block -633 -20 1969 Items[2].Count set value 64b
+data modify block -633 -20 1969 Items[3].Count set value 64b
+data modify block -633 -20 1969 Items[4].Count set value 64b
+data modify block -633 -20 1969 Items[5].Count set value 64b
+data modify block -633 -20 1969 Items[6].Count set value 64b
+data modify block -633 -20 1969 Items[7].Count set value 64b
+data modify block -633 -20 1969 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1970 Items[0].Count set value 64b
+data modify block -633 -20 1970 Items[1].Count set value 64b
+data modify block -633 -20 1970 Items[2].Count set value 64b
+data modify block -633 -20 1970 Items[3].Count set value 64b
+data modify block -633 -20 1970 Items[4].Count set value 64b
+data modify block -633 -20 1970 Items[5].Count set value 64b
+data modify block -633 -20 1970 Items[6].Count set value 64b
+data modify block -633 -20 1970 Items[7].Count set value 64b
+data modify block -633 -20 1970 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1971 Items[0].Count set value 64b
+data modify block -633 -20 1971 Items[1].Count set value 64b
+data modify block -633 -20 1971 Items[2].Count set value 64b
+data modify block -633 -20 1971 Items[3].Count set value 64b
+data modify block -633 -20 1971 Items[4].Count set value 64b
+data modify block -633 -20 1971 Items[5].Count set value 64b
+data modify block -633 -20 1971 Items[6].Count set value 64b
+data modify block -633 -20 1971 Items[7].Count set value 64b
+data modify block -633 -20 1971 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1972 Items[0].Count set value 64b
+data modify block -633 -20 1972 Items[1].Count set value 64b
+data modify block -633 -20 1972 Items[2].Count set value 64b
+data modify block -633 -20 1972 Items[3].Count set value 64b
+data modify block -633 -20 1972 Items[4].Count set value 64b
+data modify block -633 -20 1972 Items[5].Count set value 64b
+data modify block -633 -20 1972 Items[6].Count set value 64b
+data modify block -633 -20 1972 Items[7].Count set value 64b
+data modify block -633 -20 1972 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1973 Items[0].Count set value 64b
+data modify block -633 -20 1973 Items[1].Count set value 64b
+data modify block -633 -20 1973 Items[2].Count set value 64b
+data modify block -633 -20 1973 Items[3].Count set value 64b
+data modify block -633 -20 1973 Items[4].Count set value 64b
+data modify block -633 -20 1973 Items[5].Count set value 64b
+data modify block -633 -20 1973 Items[6].Count set value 64b
+data modify block -633 -20 1973 Items[7].Count set value 64b
+data modify block -633 -20 1973 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1974 Items[0].Count set value 64b
+data modify block -633 -20 1974 Items[1].Count set value 64b
+data modify block -633 -20 1974 Items[2].Count set value 64b
+data modify block -633 -20 1974 Items[3].Count set value 64b
+data modify block -633 -20 1974 Items[4].Count set value 64b
+data modify block -633 -20 1974 Items[5].Count set value 64b
+data modify block -633 -20 1974 Items[6].Count set value 64b
+data modify block -633 -20 1974 Items[7].Count set value 64b
+data modify block -633 -20 1974 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1975 Items[0].Count set value 64b
+data modify block -633 -20 1975 Items[1].Count set value 64b
+data modify block -633 -20 1975 Items[2].Count set value 64b
+data modify block -633 -20 1975 Items[3].Count set value 64b
+data modify block -633 -20 1975 Items[4].Count set value 64b
+data modify block -633 -20 1975 Items[5].Count set value 64b
+data modify block -633 -20 1975 Items[6].Count set value 64b
+data modify block -633 -20 1975 Items[7].Count set value 64b
+data modify block -633 -20 1975 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1976 Items[0].Count set value 64b
+data modify block -633 -20 1976 Items[1].Count set value 64b
+data modify block -633 -20 1976 Items[2].Count set value 64b
+data modify block -633 -20 1976 Items[3].Count set value 64b
+data modify block -633 -20 1976 Items[4].Count set value 64b
+data modify block -633 -20 1976 Items[5].Count set value 64b
+data modify block -633 -20 1976 Items[6].Count set value 64b
+data modify block -633 -20 1976 Items[7].Count set value 64b
+data modify block -633 -20 1976 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1977 Items[0].Count set value 64b
+data modify block -633 -20 1977 Items[1].Count set value 64b
+data modify block -633 -20 1977 Items[2].Count set value 64b
+data modify block -633 -20 1977 Items[3].Count set value 64b
+data modify block -633 -20 1977 Items[4].Count set value 64b
+data modify block -633 -20 1977 Items[5].Count set value 64b
+data modify block -633 -20 1977 Items[6].Count set value 64b
+data modify block -633 -20 1977 Items[7].Count set value 64b
+data modify block -633 -20 1977 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1978 Items[0].Count set value 64b
+data modify block -633 -20 1978 Items[1].Count set value 64b
+data modify block -633 -20 1978 Items[2].Count set value 64b
+data modify block -633 -20 1978 Items[3].Count set value 64b
+data modify block -633 -20 1978 Items[4].Count set value 64b
+data modify block -633 -20 1978 Items[5].Count set value 64b
+data modify block -633 -20 1978 Items[6].Count set value 64b
+data modify block -633 -20 1978 Items[7].Count set value 64b
+data modify block -633 -20 1978 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1979 Items[0].Count set value 64b
+data modify block -633 -20 1979 Items[1].Count set value 64b
+data modify block -633 -20 1979 Items[2].Count set value 64b
+data modify block -633 -20 1979 Items[3].Count set value 64b
+data modify block -633 -20 1979 Items[4].Count set value 64b
+data modify block -633 -20 1979 Items[5].Count set value 64b
+data modify block -633 -20 1979 Items[6].Count set value 64b
+data modify block -633 -20 1979 Items[7].Count set value 64b
+data modify block -633 -20 1979 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -640 -19 1889 Items[0].Count set value 64b
+data modify block -640 -19 1889 Items[1].Count set value 64b
+data modify block -640 -19 1889 Items[2].Count set value 64b
+data modify block -640 -19 1889 Items[3].Count set value 64b
+data modify block -640 -19 1889 Items[4].Count set value 64b
+data modify block -640 -19 1889 Items[5].Count set value 64b
+data modify block -640 -19 1889 Items[6].Count set value 64b
+data modify block -640 -19 1889 Items[7].Count set value 64b
+data modify block -640 -19 1889 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -642 -19 1921 Items[0].Count set value 64b
+data modify block -642 -19 1921 Items[1].Count set value 64b
+data modify block -642 -19 1921 Items[2].Count set value 64b
+data modify block -642 -19 1921 Items[3].Count set value 64b
+data modify block -642 -19 1921 Items[4].Count set value 64b
+data modify block -642 -19 1921 Items[5].Count set value 64b
+data modify block -642 -19 1921 Items[6].Count set value 64b
+data modify block -642 -19 1921 Items[7].Count set value 64b
+data modify block -642 -19 1921 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -644 1 1921 Items[0].Count set value 64b
+data modify block -644 1 1921 Items[1].Count set value 64b
+data modify block -644 1 1921 Items[2].Count set value 64b
+data modify block -644 1 1921 Items[3].Count set value 64b
+data modify block -644 1 1921 Items[4].Count set value 64b
+data modify block -644 1 1921 Items[5].Count set value 64b
+data modify block -644 1 1921 Items[6].Count set value 64b
+data modify block -644 1 1921 Items[7].Count set value 64b
+data modify block -644 1 1921 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -652 1 1892 Items[0].Count set value 64b
+data modify block -652 1 1892 Items[1].Count set value 64b
+data modify block -652 1 1892 Items[2].Count set value 64b
+data modify block -652 1 1892 Items[3].Count set value 64b
+data modify block -652 1 1892 Items[4].Count set value 64b
+data modify block -652 1 1892 Items[5].Count set value 64b
+data modify block -652 1 1892 Items[6].Count set value 64b
+data modify block -652 1 1892 Items[7].Count set value 64b
+data modify block -652 1 1892 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -654 -9 1892 Items[0].Count set value 64b
+data modify block -654 -9 1892 Items[1].Count set value 64b
+data modify block -654 -9 1892 Items[2].Count set value 64b
+data modify block -654 -9 1892 Items[3].Count set value 64b
+data modify block -654 -9 1892 Items[4].Count set value 64b
+data modify block -654 -9 1892 Items[5].Count set value 64b
+data modify block -654 -9 1892 Items[6].Count set value 64b
+data modify block -654 -9 1892 Items[7].Count set value 64b
+data modify block -654 -9 1892 Items[8].Count set value 64b
+
+# Category "Other Items"
+## Example Item: "The Bomb"
+data modify block -569 -48 1909 Items[0].Count set value 64b
+data modify block -569 -48 1909 Items[1].Count set value 64b
+data modify block -569 -48 1909 Items[2].Count set value 64b
+data modify block -569 -48 1909 Items[3].Count set value 64b
+data modify block -569 -48 1909 Items[4].Count set value 64b
+data modify block -569 -48 1909 Items[5].Count set value 64b
+data modify block -569 -48 1909 Items[6].Count set value 64b
+data modify block -569 -48 1909 Items[7].Count set value 64b
+data modify block -569 -48 1909 Items[8].Count set value 64b
+
+## Example Item: "The Bomb"
+data modify block -598 -51 1876 Items[0].Count set value 64b
+data modify block -598 -51 1876 Items[1].Count set value 64b
+data modify block -598 -51 1876 Items[2].Count set value 64b
+data modify block -598 -51 1876 Items[3].Count set value 64b
+data modify block -598 -51 1876 Items[4].Count set value 64b
+data modify block -598 -51 1876 Items[5].Count set value 64b
+data modify block -598 -51 1876 Items[6].Count set value 64b
+data modify block -598 -51 1876 Items[7].Count set value 64b
+data modify block -598 -51 1876 Items[8].Count set value 64b
+
+## Example Item: "The Bomb"
+data modify block -602 -51 1843 Items[0].Count set value 64b
+data modify block -602 -51 1843 Items[1].Count set value 64b
+data modify block -602 -51 1843 Items[2].Count set value 64b
+data modify block -602 -51 1843 Items[3].Count set value 64b
+data modify block -602 -51 1843 Items[4].Count set value 64b
+data modify block -602 -51 1843 Items[5].Count set value 64b
+data modify block -602 -51 1843 Items[6].Count set value 64b
+data modify block -602 -51 1843 Items[7].Count set value 64b
+data modify block -602 -51 1843 Items[8].Count set value 64b
+
+## Example Item: "The Bomb"
+data modify block -605 -49 1910 Items[0].Count set value 64b
+data modify block -605 -49 1910 Items[1].Count set value 64b
+data modify block -605 -49 1910 Items[2].Count set value 64b
+data modify block -605 -49 1910 Items[3].Count set value 64b
+data modify block -605 -49 1910 Items[4].Count set value 64b
+data modify block -605 -49 1910 Items[5].Count set value 64b
+data modify block -605 -49 1910 Items[6].Count set value 64b
+data modify block -605 -49 1910 Items[7].Count set value 64b
+data modify block -605 -49 1910 Items[8].Count set value 64b
+
+## Example Item: "The Bomb"
+data modify block -637 -51 1872 Items[0].Count set value 64b
+data modify block -637 -51 1872 Items[1].Count set value 64b
+data modify block -637 -51 1872 Items[2].Count set value 64b
+data modify block -637 -51 1872 Items[3].Count set value 64b
+data modify block -637 -51 1872 Items[4].Count set value 64b
+data modify block -637 -51 1872 Items[5].Count set value 64b
+data modify block -637 -51 1872 Items[6].Count set value 64b
+data modify block -637 -51 1872 Items[7].Count set value 64b
+data modify block -637 -51 1872 Items[8].Count set value 64b
+
+## Example Item: "Victory Tome"
+data modify block -644 -20 1992 Items[0].Count set value 64b
+data modify block -644 -20 1992 Items[1].Count set value 64b
+data modify block -644 -20 1992 Items[2].Count set value 64b
+data modify block -644 -20 1992 Items[3].Count set value 64b
+data modify block -644 -20 1992 Items[4].Count set value 64b
+data modify block -644 -20 1992 Items[5].Count set value 64b
+data modify block -644 -20 1992 Items[6].Count set value 64b
+data modify block -644 -20 1992 Items[7].Count set value 64b
+data modify block -644 -20 1992 Items[8].Count set value 64b
+
+## Example Item: "Victory Tome"
+data modify block -644 -20 1994 Items[0].Count set value 64b
+data modify block -644 -20 1994 Items[1].Count set value 64b
+data modify block -644 -20 1994 Items[2].Count set value 64b
+data modify block -644 -20 1994 Items[3].Count set value 64b
+data modify block -644 -20 1994 Items[4].Count set value 64b
+data modify block -644 -20 1994 Items[5].Count set value 64b
+data modify block -644 -20 1994 Items[6].Count set value 64b
+data modify block -644 -20 1994 Items[7].Count set value 64b
+data modify block -644 -20 1994 Items[8].Count set value 64b
+
+## Example Item: "Victory Tome"
+data modify block -644 -20 1996 Items[0].Count set value 64b
+data modify block -644 -20 1996 Items[1].Count set value 64b
+data modify block -644 -20 1996 Items[2].Count set value 64b
+data modify block -644 -20 1996 Items[3].Count set value 64b
+data modify block -644 -20 1996 Items[4].Count set value 64b
+data modify block -644 -20 1996 Items[5].Count set value 64b
+data modify block -644 -20 1996 Items[6].Count set value 64b
+data modify block -644 -20 1996 Items[7].Count set value 64b
+data modify block -644 -20 1996 Items[8].Count set value 64b
+
+## Example Item: "minecraft:cooked_porkchop"
+data modify block -627 59 1945 Items[0].Count set value 64b
+data modify block -627 59 1945 Items[1].Count set value 64b
+data modify block -627 59 1945 Items[2].Count set value 64b
+data modify block -627 59 1945 Items[3].Count set value 64b
+data modify block -627 59 1945 Items[4].Count set value 64b
+data modify block -627 59 1945 Items[5].Count set value 64b
+data modify block -627 59 1945 Items[6].Count set value 64b
+data modify block -627 59 1945 Items[7].Count set value 64b
+data modify block -627 59 1945 Items[8].Count set value 64b
+
+## Example Item: "minecraft:diamond_chestplate"
+data modify block -629 59 1945 Items[0].Count set value 64b
+data modify block -629 59 1945 Items[1].Count set value 64b
+data modify block -629 59 1945 Items[2].Count set value 64b
+data modify block -629 59 1945 Items[3].Count set value 64b
+data modify block -629 59 1945 Items[4].Count set value 64b
+data modify block -629 59 1945 Items[5].Count set value 64b
+data modify block -629 59 1945 Items[6].Count set value 64b
+data modify block -629 59 1945 Items[7].Count set value 64b
+data modify block -629 59 1945 Items[8].Count set value 64b
+
+## Example Item: "minecraft:diamond_leggings"
+data modify block -630 59 1945 Items[0].Count set value 64b
+data modify block -630 59 1945 Items[1].Count set value 64b
+data modify block -630 59 1945 Items[2].Count set value 64b
+data modify block -630 59 1945 Items[3].Count set value 64b
+data modify block -630 59 1945 Items[4].Count set value 64b
+data modify block -630 59 1945 Items[5].Count set value 64b
+data modify block -630 59 1945 Items[6].Count set value 64b
+data modify block -630 59 1945 Items[7].Count set value 64b
+data modify block -630 59 1945 Items[8].Count set value 64b
+
+## Example Item: "minecraft:filled_map"
+data modify block -625 59 1945 Items[0].Count set value 64b
+data modify block -625 59 1945 Items[1].Count set value 64b
+data modify block -625 59 1945 Items[2].Count set value 64b
+data modify block -625 59 1945 Items[3].Count set value 64b
+data modify block -625 59 1945 Items[4].Count set value 64b
+data modify block -625 59 1945 Items[5].Count set value 64b
+data modify block -625 59 1945 Items[6].Count set value 64b
+data modify block -625 59 1945 Items[7].Count set value 64b
+data modify block -625 59 1945 Items[8].Count set value 64b
+
+## Example Item: "minecraft:tnt"
+data modify block -579 -39 1843 Items[0].Count set value 64b
+data modify block -579 -39 1843 Items[1].Count set value 64b
+data modify block -579 -39 1843 Items[2].Count set value 64b
+data modify block -579 -39 1843 Items[3].Count set value 64b
+data modify block -579 -39 1843 Items[4].Count set value 64b
+data modify block -579 -39 1843 Items[5].Count set value 64b
+data modify block -579 -39 1843 Items[6].Count set value 64b
+data modify block -579 -39 1843 Items[7].Count set value 64b
+data modify block -579 -39 1843 Items[8].Count set value 64b
+
+## Example Item: "minecraft:tnt"
+data modify block -640 17 1904 Items[0].Count set value 64b
+data modify block -640 17 1904 Items[1].Count set value 64b
+data modify block -640 17 1904 Items[2].Count set value 64b
+data modify block -640 17 1904 Items[3].Count set value 64b
+data modify block -640 17 1904 Items[4].Count set value 64b
+data modify block -640 17 1904 Items[5].Count set value 64b
+data modify block -640 17 1904 Items[6].Count set value 64b
+data modify block -640 17 1904 Items[7].Count set value 64b
+data modify block -640 17 1904 Items[8].Count set value 64b
+
+# Category "Suit Up Armor"
+## Example Item: "minecraft:diamond_chestplate"
+data modify block -629 59 1945 Items[0].Count set value 64b
+data modify block -629 59 1945 Items[1].Count set value 64b
+data modify block -629 59 1945 Items[2].Count set value 64b
+data modify block -629 59 1945 Items[3].Count set value 64b
+data modify block -629 59 1945 Items[4].Count set value 64b
+data modify block -629 59 1945 Items[5].Count set value 64b
+data modify block -629 59 1945 Items[6].Count set value 64b
+data modify block -629 59 1945 Items[7].Count set value 64b
+data modify block -629 59 1945 Items[8].Count set value 64b
+
+## Example Item: "minecraft:diamond_leggings"
+data modify block -630 59 1945 Items[0].Count set value 64b
+data modify block -630 59 1945 Items[1].Count set value 64b
+data modify block -630 59 1945 Items[2].Count set value 64b
+data modify block -630 59 1945 Items[3].Count set value 64b
+data modify block -630 59 1945 Items[4].Count set value 64b
+data modify block -630 59 1945 Items[5].Count set value 64b
+data modify block -630 59 1945 Items[6].Count set value 64b
+data modify block -630 59 1945 Items[7].Count set value 64b
+data modify block -630 59 1945 Items[8].Count set value 64b
+
+# Category "Treasure"
+## Example Item: "Decked Out Coin"
+data modify block -479 19 2009 Items[0].Count set value 64b
+data modify block -479 19 2009 Items[1].Count set value 64b
+data modify block -479 19 2009 Items[2].Count set value 64b
+data modify block -479 19 2009 Items[3].Count set value 64b
+data modify block -479 19 2009 Items[4].Count set value 64b
+data modify block -479 19 2009 Items[5].Count set value 64b
+data modify block -479 19 2009 Items[6].Count set value 64b
+data modify block -479 19 2009 Items[7].Count set value 64b
+data modify block -479 19 2009 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -484 53 1989 Items[0].Count set value 64b
+data modify block -484 53 1989 Items[1].Count set value 64b
+data modify block -484 53 1989 Items[2].Count set value 64b
+data modify block -484 53 1989 Items[3].Count set value 64b
+data modify block -484 53 1989 Items[4].Count set value 64b
+data modify block -484 53 1989 Items[5].Count set value 64b
+data modify block -484 53 1989 Items[6].Count set value 64b
+data modify block -484 53 1989 Items[7].Count set value 64b
+data modify block -484 53 1989 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -485 31 1963 Items[0].Count set value 64b
+data modify block -485 31 1963 Items[1].Count set value 64b
+data modify block -485 31 1963 Items[2].Count set value 64b
+data modify block -485 31 1963 Items[3].Count set value 64b
+data modify block -485 31 1963 Items[4].Count set value 64b
+data modify block -485 31 1963 Items[5].Count set value 64b
+data modify block -485 31 1963 Items[6].Count set value 64b
+data modify block -485 31 1963 Items[7].Count set value 64b
+data modify block -485 31 1963 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -490 11 2007 Items[0].Count set value 64b
+data modify block -490 11 2007 Items[1].Count set value 64b
+data modify block -490 11 2007 Items[2].Count set value 64b
+data modify block -490 11 2007 Items[3].Count set value 64b
+data modify block -490 11 2007 Items[4].Count set value 64b
+data modify block -490 11 2007 Items[5].Count set value 64b
+data modify block -490 11 2007 Items[6].Count set value 64b
+data modify block -490 11 2007 Items[7].Count set value 64b
+data modify block -490 11 2007 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -490 50 2017 Items[0].Count set value 64b
+data modify block -490 50 2017 Items[1].Count set value 64b
+data modify block -490 50 2017 Items[2].Count set value 64b
+data modify block -490 50 2017 Items[3].Count set value 64b
+data modify block -490 50 2017 Items[4].Count set value 64b
+data modify block -490 50 2017 Items[5].Count set value 64b
+data modify block -490 50 2017 Items[6].Count set value 64b
+data modify block -490 50 2017 Items[7].Count set value 64b
+data modify block -490 50 2017 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -497 51 1980 Items[0].Count set value 64b
+data modify block -497 51 1980 Items[1].Count set value 64b
+data modify block -497 51 1980 Items[2].Count set value 64b
+data modify block -497 51 1980 Items[3].Count set value 64b
+data modify block -497 51 1980 Items[4].Count set value 64b
+data modify block -497 51 1980 Items[5].Count set value 64b
+data modify block -497 51 1980 Items[6].Count set value 64b
+data modify block -497 51 1980 Items[7].Count set value 64b
+data modify block -497 51 1980 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -502 16 1972 Items[0].Count set value 64b
+data modify block -502 16 1972 Items[1].Count set value 64b
+data modify block -502 16 1972 Items[2].Count set value 64b
+data modify block -502 16 1972 Items[3].Count set value 64b
+data modify block -502 16 1972 Items[4].Count set value 64b
+data modify block -502 16 1972 Items[5].Count set value 64b
+data modify block -502 16 1972 Items[6].Count set value 64b
+data modify block -502 16 1972 Items[7].Count set value 64b
+data modify block -502 16 1972 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -507 9 1951 Items[0].Count set value 64b
+data modify block -507 9 1951 Items[1].Count set value 64b
+data modify block -507 9 1951 Items[2].Count set value 64b
+data modify block -507 9 1951 Items[3].Count set value 64b
+data modify block -507 9 1951 Items[4].Count set value 64b
+data modify block -507 9 1951 Items[5].Count set value 64b
+data modify block -507 9 1951 Items[6].Count set value 64b
+data modify block -507 9 1951 Items[7].Count set value 64b
+data modify block -507 9 1951 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -509 14 2034 Items[0].Count set value 64b
+data modify block -509 14 2034 Items[1].Count set value 64b
+data modify block -509 14 2034 Items[2].Count set value 64b
+data modify block -509 14 2034 Items[3].Count set value 64b
+data modify block -509 14 2034 Items[4].Count set value 64b
+data modify block -509 14 2034 Items[5].Count set value 64b
+data modify block -509 14 2034 Items[6].Count set value 64b
+data modify block -509 14 2034 Items[7].Count set value 64b
+data modify block -509 14 2034 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -514 51 1962 Items[0].Count set value 64b
+data modify block -514 51 1962 Items[1].Count set value 64b
+data modify block -514 51 1962 Items[2].Count set value 64b
+data modify block -514 51 1962 Items[3].Count set value 64b
+data modify block -514 51 1962 Items[4].Count set value 64b
+data modify block -514 51 1962 Items[5].Count set value 64b
+data modify block -514 51 1962 Items[6].Count set value 64b
+data modify block -514 51 1962 Items[7].Count set value 64b
+data modify block -514 51 1962 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -516 46 2031 Items[0].Count set value 64b
+data modify block -516 46 2031 Items[1].Count set value 64b
+data modify block -516 46 2031 Items[2].Count set value 64b
+data modify block -516 46 2031 Items[3].Count set value 64b
+data modify block -516 46 2031 Items[4].Count set value 64b
+data modify block -516 46 2031 Items[5].Count set value 64b
+data modify block -516 46 2031 Items[6].Count set value 64b
+data modify block -516 46 2031 Items[7].Count set value 64b
+data modify block -516 46 2031 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -521 35 1982 Items[0].Count set value 64b
+data modify block -521 35 1982 Items[1].Count set value 64b
+data modify block -521 35 1982 Items[2].Count set value 64b
+data modify block -521 35 1982 Items[3].Count set value 64b
+data modify block -521 35 1982 Items[4].Count set value 64b
+data modify block -521 35 1982 Items[5].Count set value 64b
+data modify block -521 35 1982 Items[6].Count set value 64b
+data modify block -521 35 1982 Items[7].Count set value 64b
+data modify block -521 35 1982 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -527 51 1973 Items[0].Count set value 64b
+data modify block -527 51 1973 Items[1].Count set value 64b
+data modify block -527 51 1973 Items[2].Count set value 64b
+data modify block -527 51 1973 Items[3].Count set value 64b
+data modify block -527 51 1973 Items[4].Count set value 64b
+data modify block -527 51 1973 Items[5].Count set value 64b
+data modify block -527 51 1973 Items[6].Count set value 64b
+data modify block -527 51 1973 Items[7].Count set value 64b
+data modify block -527 51 1973 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -531 16 1990 Items[0].Count set value 64b
+data modify block -531 16 1990 Items[1].Count set value 64b
+data modify block -531 16 1990 Items[2].Count set value 64b
+data modify block -531 16 1990 Items[3].Count set value 64b
+data modify block -531 16 1990 Items[4].Count set value 64b
+data modify block -531 16 1990 Items[5].Count set value 64b
+data modify block -531 16 1990 Items[6].Count set value 64b
+data modify block -531 16 1990 Items[7].Count set value 64b
+data modify block -531 16 1990 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -532 44 2024 Items[0].Count set value 64b
+data modify block -532 44 2024 Items[1].Count set value 64b
+data modify block -532 44 2024 Items[2].Count set value 64b
+data modify block -532 44 2024 Items[3].Count set value 64b
+data modify block -532 44 2024 Items[4].Count set value 64b
+data modify block -532 44 2024 Items[5].Count set value 64b
+data modify block -532 44 2024 Items[6].Count set value 64b
+data modify block -532 44 2024 Items[7].Count set value 64b
+data modify block -532 44 2024 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -536 45 1948 Items[0].Count set value 64b
+data modify block -536 45 1948 Items[1].Count set value 64b
+data modify block -536 45 1948 Items[2].Count set value 64b
+data modify block -536 45 1948 Items[3].Count set value 64b
+data modify block -536 45 1948 Items[4].Count set value 64b
+data modify block -536 45 1948 Items[5].Count set value 64b
+data modify block -536 45 1948 Items[6].Count set value 64b
+data modify block -536 45 1948 Items[7].Count set value 64b
+data modify block -536 45 1948 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -546 51 2008 Items[0].Count set value 64b
+data modify block -546 51 2008 Items[1].Count set value 64b
+data modify block -546 51 2008 Items[2].Count set value 64b
+data modify block -546 51 2008 Items[3].Count set value 64b
+data modify block -546 51 2008 Items[4].Count set value 64b
+data modify block -546 51 2008 Items[5].Count set value 64b
+data modify block -546 51 2008 Items[6].Count set value 64b
+data modify block -546 51 2008 Items[7].Count set value 64b
+data modify block -546 51 2008 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -554 51 2007 Items[0].Count set value 64b
+data modify block -554 51 2007 Items[1].Count set value 64b
+data modify block -554 51 2007 Items[2].Count set value 64b
+data modify block -554 51 2007 Items[3].Count set value 64b
+data modify block -554 51 2007 Items[4].Count set value 64b
+data modify block -554 51 2007 Items[5].Count set value 64b
+data modify block -554 51 2007 Items[6].Count set value 64b
+data modify block -554 51 2007 Items[7].Count set value 64b
+data modify block -554 51 2007 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -557 45 1976 Items[0].Count set value 64b
+data modify block -557 45 1976 Items[1].Count set value 64b
+data modify block -557 45 1976 Items[2].Count set value 64b
+data modify block -557 45 1976 Items[3].Count set value 64b
+data modify block -557 45 1976 Items[4].Count set value 64b
+data modify block -557 45 1976 Items[5].Count set value 64b
+data modify block -557 45 1976 Items[6].Count set value 64b
+data modify block -557 45 1976 Items[7].Count set value 64b
+data modify block -557 45 1976 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -559 46 2022 Items[0].Count set value 64b
+data modify block -559 46 2022 Items[1].Count set value 64b
+data modify block -559 46 2022 Items[2].Count set value 64b
+data modify block -559 46 2022 Items[3].Count set value 64b
+data modify block -559 46 2022 Items[4].Count set value 64b
+data modify block -559 46 2022 Items[5].Count set value 64b
+data modify block -559 46 2022 Items[6].Count set value 64b
+data modify block -559 46 2022 Items[7].Count set value 64b
+data modify block -559 46 2022 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -561 47 1942 Items[0].Count set value 64b
+data modify block -561 47 1942 Items[1].Count set value 64b
+data modify block -561 47 1942 Items[2].Count set value 64b
+data modify block -561 47 1942 Items[3].Count set value 64b
+data modify block -561 47 1942 Items[4].Count set value 64b
+data modify block -561 47 1942 Items[5].Count set value 64b
+data modify block -561 47 1942 Items[6].Count set value 64b
+data modify block -561 47 1942 Items[7].Count set value 64b
+data modify block -561 47 1942 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -563 36 1999 Items[0].Count set value 64b
+data modify block -563 36 1999 Items[1].Count set value 64b
+data modify block -563 36 1999 Items[2].Count set value 64b
+data modify block -563 36 1999 Items[3].Count set value 64b
+data modify block -563 36 1999 Items[4].Count set value 64b
+data modify block -563 36 1999 Items[5].Count set value 64b
+data modify block -563 36 1999 Items[6].Count set value 64b
+data modify block -563 36 1999 Items[7].Count set value 64b
+data modify block -563 36 1999 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -578 15 1968 Items[0].Count set value 64b
+data modify block -578 15 1968 Items[1].Count set value 64b
+data modify block -578 15 1968 Items[2].Count set value 64b
+data modify block -578 15 1968 Items[3].Count set value 64b
+data modify block -578 15 1968 Items[4].Count set value 64b
+data modify block -578 15 1968 Items[5].Count set value 64b
+data modify block -578 15 1968 Items[6].Count set value 64b
+data modify block -578 15 1968 Items[7].Count set value 64b
+data modify block -578 15 1968 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -583 45 2012 Items[0].Count set value 64b
+data modify block -583 45 2012 Items[1].Count set value 64b
+data modify block -583 45 2012 Items[2].Count set value 64b
+data modify block -583 45 2012 Items[3].Count set value 64b
+data modify block -583 45 2012 Items[4].Count set value 64b
+data modify block -583 45 2012 Items[5].Count set value 64b
+data modify block -583 45 2012 Items[6].Count set value 64b
+data modify block -583 45 2012 Items[7].Count set value 64b
+data modify block -583 45 2012 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -588 52 1951 Items[0].Count set value 64b
+data modify block -588 52 1951 Items[1].Count set value 64b
+data modify block -588 52 1951 Items[2].Count set value 64b
+data modify block -588 52 1951 Items[3].Count set value 64b
+data modify block -588 52 1951 Items[4].Count set value 64b
+data modify block -588 52 1951 Items[5].Count set value 64b
+data modify block -588 52 1951 Items[6].Count set value 64b
+data modify block -588 52 1951 Items[7].Count set value 64b
+data modify block -588 52 1951 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -590 11 2032 Items[0].Count set value 64b
+data modify block -590 11 2032 Items[1].Count set value 64b
+data modify block -590 11 2032 Items[2].Count set value 64b
+data modify block -590 11 2032 Items[3].Count set value 64b
+data modify block -590 11 2032 Items[4].Count set value 64b
+data modify block -590 11 2032 Items[5].Count set value 64b
+data modify block -590 11 2032 Items[6].Count set value 64b
+data modify block -590 11 2032 Items[7].Count set value 64b
+data modify block -590 11 2032 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -590 46 1978 Items[0].Count set value 64b
+data modify block -590 46 1978 Items[1].Count set value 64b
+data modify block -590 46 1978 Items[2].Count set value 64b
+data modify block -590 46 1978 Items[3].Count set value 64b
+data modify block -590 46 1978 Items[4].Count set value 64b
+data modify block -590 46 1978 Items[5].Count set value 64b
+data modify block -590 46 1978 Items[6].Count set value 64b
+data modify block -590 46 1978 Items[7].Count set value 64b
+data modify block -590 46 1978 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -594 12 1954 Items[0].Count set value 64b
+data modify block -594 12 1954 Items[1].Count set value 64b
+data modify block -594 12 1954 Items[2].Count set value 64b
+data modify block -594 12 1954 Items[3].Count set value 64b
+data modify block -594 12 1954 Items[4].Count set value 64b
+data modify block -594 12 1954 Items[5].Count set value 64b
+data modify block -594 12 1954 Items[6].Count set value 64b
+data modify block -594 12 1954 Items[7].Count set value 64b
+data modify block -594 12 1954 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -597 12 2009 Items[0].Count set value 64b
+data modify block -597 12 2009 Items[1].Count set value 64b
+data modify block -597 12 2009 Items[2].Count set value 64b
+data modify block -597 12 2009 Items[3].Count set value 64b
+data modify block -597 12 2009 Items[4].Count set value 64b
+data modify block -597 12 2009 Items[5].Count set value 64b
+data modify block -597 12 2009 Items[6].Count set value 64b
+data modify block -597 12 2009 Items[7].Count set value 64b
+data modify block -597 12 2009 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -598 11 1988 Items[0].Count set value 64b
+data modify block -598 11 1988 Items[1].Count set value 64b
+data modify block -598 11 1988 Items[2].Count set value 64b
+data modify block -598 11 1988 Items[3].Count set value 64b
+data modify block -598 11 1988 Items[4].Count set value 64b
+data modify block -598 11 1988 Items[5].Count set value 64b
+data modify block -598 11 1988 Items[6].Count set value 64b
+data modify block -598 11 1988 Items[7].Count set value 64b
+data modify block -598 11 1988 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -606 43 2024 Items[0].Count set value 64b
+data modify block -606 43 2024 Items[1].Count set value 64b
+data modify block -606 43 2024 Items[2].Count set value 64b
+data modify block -606 43 2024 Items[3].Count set value 64b
+data modify block -606 43 2024 Items[4].Count set value 64b
+data modify block -606 43 2024 Items[5].Count set value 64b
+data modify block -606 43 2024 Items[6].Count set value 64b
+data modify block -606 43 2024 Items[7].Count set value 64b
+data modify block -606 43 2024 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -619 43 2027 Items[0].Count set value 64b
+data modify block -619 43 2027 Items[1].Count set value 64b
+data modify block -619 43 2027 Items[2].Count set value 64b
+data modify block -619 43 2027 Items[3].Count set value 64b
+data modify block -619 43 2027 Items[4].Count set value 64b
+data modify block -619 43 2027 Items[5].Count set value 64b
+data modify block -619 43 2027 Items[6].Count set value 64b
+data modify block -619 43 2027 Items[7].Count set value 64b
+data modify block -619 43 2027 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -628 1 1920 Items[0].Count set value 64b
+data modify block -628 1 1920 Items[1].Count set value 64b
+data modify block -628 1 1920 Items[2].Count set value 64b
+data modify block -628 1 1920 Items[3].Count set value 64b
+data modify block -628 1 1920 Items[4].Count set value 64b
+data modify block -628 1 1920 Items[5].Count set value 64b
+data modify block -628 1 1920 Items[6].Count set value 64b
+data modify block -628 1 1920 Items[7].Count set value 64b
+data modify block -628 1 1920 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Coin"
+data modify block -640 -19 1888 Items[0].Count set value 64b
+data modify block -640 -19 1888 Items[1].Count set value 64b
+data modify block -640 -19 1888 Items[2].Count set value 64b
+data modify block -640 -19 1888 Items[3].Count set value 64b
+data modify block -640 -19 1888 Items[4].Count set value 64b
+data modify block -640 -19 1888 Items[5].Count set value 64b
+data modify block -640 -19 1888 Items[6].Count set value 64b
+data modify block -640 -19 1888 Items[7].Count set value 64b
+data modify block -640 -19 1888 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -496 15 2000 Items[0].Count set value 64b
+data modify block -496 15 2000 Items[1].Count set value 64b
+data modify block -496 15 2000 Items[2].Count set value 64b
+data modify block -496 15 2000 Items[3].Count set value 64b
+data modify block -496 15 2000 Items[4].Count set value 64b
+data modify block -496 15 2000 Items[5].Count set value 64b
+data modify block -496 15 2000 Items[6].Count set value 64b
+data modify block -496 15 2000 Items[7].Count set value 64b
+data modify block -496 15 2000 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -523 12 2042 Items[0].Count set value 64b
+data modify block -523 12 2042 Items[1].Count set value 64b
+data modify block -523 12 2042 Items[2].Count set value 64b
+data modify block -523 12 2042 Items[3].Count set value 64b
+data modify block -523 12 2042 Items[4].Count set value 64b
+data modify block -523 12 2042 Items[5].Count set value 64b
+data modify block -523 12 2042 Items[6].Count set value 64b
+data modify block -523 12 2042 Items[7].Count set value 64b
+data modify block -523 12 2042 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -526 12 1942 Items[0].Count set value 64b
+data modify block -526 12 1942 Items[1].Count set value 64b
+data modify block -526 12 1942 Items[2].Count set value 64b
+data modify block -526 12 1942 Items[3].Count set value 64b
+data modify block -526 12 1942 Items[4].Count set value 64b
+data modify block -526 12 1942 Items[5].Count set value 64b
+data modify block -526 12 1942 Items[6].Count set value 64b
+data modify block -526 12 1942 Items[7].Count set value 64b
+data modify block -526 12 1942 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -528 12 2031 Items[0].Count set value 64b
+data modify block -528 12 2031 Items[1].Count set value 64b
+data modify block -528 12 2031 Items[2].Count set value 64b
+data modify block -528 12 2031 Items[3].Count set value 64b
+data modify block -528 12 2031 Items[4].Count set value 64b
+data modify block -528 12 2031 Items[5].Count set value 64b
+data modify block -528 12 2031 Items[6].Count set value 64b
+data modify block -528 12 2031 Items[7].Count set value 64b
+data modify block -528 12 2031 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -541 11 1998 Items[0].Count set value 64b
+data modify block -541 11 1998 Items[1].Count set value 64b
+data modify block -541 11 1998 Items[2].Count set value 64b
+data modify block -541 11 1998 Items[3].Count set value 64b
+data modify block -541 11 1998 Items[4].Count set value 64b
+data modify block -541 11 1998 Items[5].Count set value 64b
+data modify block -541 11 1998 Items[6].Count set value 64b
+data modify block -541 11 1998 Items[7].Count set value 64b
+data modify block -541 11 1998 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -548 11 1975 Items[0].Count set value 64b
+data modify block -548 11 1975 Items[1].Count set value 64b
+data modify block -548 11 1975 Items[2].Count set value 64b
+data modify block -548 11 1975 Items[3].Count set value 64b
+data modify block -548 11 1975 Items[4].Count set value 64b
+data modify block -548 11 1975 Items[5].Count set value 64b
+data modify block -548 11 1975 Items[6].Count set value 64b
+data modify block -548 11 1975 Items[7].Count set value 64b
+data modify block -548 11 1975 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -568 8 1964 Items[0].Count set value 64b
+data modify block -568 8 1964 Items[1].Count set value 64b
+data modify block -568 8 1964 Items[2].Count set value 64b
+data modify block -568 8 1964 Items[3].Count set value 64b
+data modify block -568 8 1964 Items[4].Count set value 64b
+data modify block -568 8 1964 Items[5].Count set value 64b
+data modify block -568 8 1964 Items[6].Count set value 64b
+data modify block -568 8 1964 Items[7].Count set value 64b
+data modify block -568 8 1964 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -574 11 2007 Items[0].Count set value 64b
+data modify block -574 11 2007 Items[1].Count set value 64b
+data modify block -574 11 2007 Items[2].Count set value 64b
+data modify block -574 11 2007 Items[3].Count set value 64b
+data modify block -574 11 2007 Items[4].Count set value 64b
+data modify block -574 11 2007 Items[5].Count set value 64b
+data modify block -574 11 2007 Items[6].Count set value 64b
+data modify block -574 11 2007 Items[7].Count set value 64b
+data modify block -574 11 2007 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -575 36 1998 Items[0].Count set value 64b
+data modify block -575 36 1998 Items[1].Count set value 64b
+data modify block -575 36 1998 Items[2].Count set value 64b
+data modify block -575 36 1998 Items[3].Count set value 64b
+data modify block -575 36 1998 Items[4].Count set value 64b
+data modify block -575 36 1998 Items[5].Count set value 64b
+data modify block -575 36 1998 Items[6].Count set value 64b
+data modify block -575 36 1998 Items[7].Count set value 64b
+data modify block -575 36 1998 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -577 -37 1837 Items[0].Count set value 64b
+data modify block -577 -37 1837 Items[1].Count set value 64b
+data modify block -577 -37 1837 Items[2].Count set value 64b
+data modify block -577 -37 1837 Items[3].Count set value 64b
+data modify block -577 -37 1837 Items[4].Count set value 64b
+data modify block -577 -37 1837 Items[5].Count set value 64b
+data modify block -577 -37 1837 Items[6].Count set value 64b
+data modify block -577 -37 1837 Items[7].Count set value 64b
+data modify block -577 -37 1837 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -578 15 1970 Items[0].Count set value 64b
+data modify block -578 15 1970 Items[1].Count set value 64b
+data modify block -578 15 1970 Items[2].Count set value 64b
+data modify block -578 15 1970 Items[3].Count set value 64b
+data modify block -578 15 1970 Items[4].Count set value 64b
+data modify block -578 15 1970 Items[5].Count set value 64b
+data modify block -578 15 1970 Items[6].Count set value 64b
+data modify block -578 15 1970 Items[7].Count set value 64b
+data modify block -578 15 1970 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -581 9 1955 Items[0].Count set value 64b
+data modify block -581 9 1955 Items[1].Count set value 64b
+data modify block -581 9 1955 Items[2].Count set value 64b
+data modify block -581 9 1955 Items[3].Count set value 64b
+data modify block -581 9 1955 Items[4].Count set value 64b
+data modify block -581 9 1955 Items[5].Count set value 64b
+data modify block -581 9 1955 Items[6].Count set value 64b
+data modify block -581 9 1955 Items[7].Count set value 64b
+data modify block -581 9 1955 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -583 -17 1927 Items[0].Count set value 64b
+data modify block -583 -17 1927 Items[1].Count set value 64b
+data modify block -583 -17 1927 Items[2].Count set value 64b
+data modify block -583 -17 1927 Items[3].Count set value 64b
+data modify block -583 -17 1927 Items[4].Count set value 64b
+data modify block -583 -17 1927 Items[5].Count set value 64b
+data modify block -583 -17 1927 Items[6].Count set value 64b
+data modify block -583 -17 1927 Items[7].Count set value 64b
+data modify block -583 -17 1927 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -585 -9 1919 Items[0].Count set value 64b
+data modify block -585 -9 1919 Items[1].Count set value 64b
+data modify block -585 -9 1919 Items[2].Count set value 64b
+data modify block -585 -9 1919 Items[3].Count set value 64b
+data modify block -585 -9 1919 Items[4].Count set value 64b
+data modify block -585 -9 1919 Items[5].Count set value 64b
+data modify block -585 -9 1919 Items[6].Count set value 64b
+data modify block -585 -9 1919 Items[7].Count set value 64b
+data modify block -585 -9 1919 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -586 1 1887 Items[0].Count set value 64b
+data modify block -586 1 1887 Items[1].Count set value 64b
+data modify block -586 1 1887 Items[2].Count set value 64b
+data modify block -586 1 1887 Items[3].Count set value 64b
+data modify block -586 1 1887 Items[4].Count set value 64b
+data modify block -586 1 1887 Items[5].Count set value 64b
+data modify block -586 1 1887 Items[6].Count set value 64b
+data modify block -586 1 1887 Items[7].Count set value 64b
+data modify block -586 1 1887 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -590 1 1901 Items[0].Count set value 64b
+data modify block -590 1 1901 Items[1].Count set value 64b
+data modify block -590 1 1901 Items[2].Count set value 64b
+data modify block -590 1 1901 Items[3].Count set value 64b
+data modify block -590 1 1901 Items[4].Count set value 64b
+data modify block -590 1 1901 Items[5].Count set value 64b
+data modify block -590 1 1901 Items[6].Count set value 64b
+data modify block -590 1 1901 Items[7].Count set value 64b
+data modify block -590 1 1901 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -603 -9 1885 Items[0].Count set value 64b
+data modify block -603 -9 1885 Items[1].Count set value 64b
+data modify block -603 -9 1885 Items[2].Count set value 64b
+data modify block -603 -9 1885 Items[3].Count set value 64b
+data modify block -603 -9 1885 Items[4].Count set value 64b
+data modify block -603 -9 1885 Items[5].Count set value 64b
+data modify block -603 -9 1885 Items[6].Count set value 64b
+data modify block -603 -9 1885 Items[7].Count set value 64b
+data modify block -603 -9 1885 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -606 1 1920 Items[0].Count set value 64b
+data modify block -606 1 1920 Items[1].Count set value 64b
+data modify block -606 1 1920 Items[2].Count set value 64b
+data modify block -606 1 1920 Items[3].Count set value 64b
+data modify block -606 1 1920 Items[4].Count set value 64b
+data modify block -606 1 1920 Items[5].Count set value 64b
+data modify block -606 1 1920 Items[6].Count set value 64b
+data modify block -606 1 1920 Items[7].Count set value 64b
+data modify block -606 1 1920 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -608 -19 1919 Items[0].Count set value 64b
+data modify block -608 -19 1919 Items[1].Count set value 64b
+data modify block -608 -19 1919 Items[2].Count set value 64b
+data modify block -608 -19 1919 Items[3].Count set value 64b
+data modify block -608 -19 1919 Items[4].Count set value 64b
+data modify block -608 -19 1919 Items[5].Count set value 64b
+data modify block -608 -19 1919 Items[6].Count set value 64b
+data modify block -608 -19 1919 Items[7].Count set value 64b
+data modify block -608 -19 1919 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -632 -12 1990 Items[0].Count set value 64b
+data modify block -632 -12 1990 Items[1].Count set value 64b
+data modify block -632 -12 1990 Items[2].Count set value 64b
+data modify block -632 -12 1990 Items[3].Count set value 64b
+data modify block -632 -12 1990 Items[4].Count set value 64b
+data modify block -632 -12 1990 Items[5].Count set value 64b
+data modify block -632 -12 1990 Items[6].Count set value 64b
+data modify block -632 -12 1990 Items[7].Count set value 64b
+data modify block -632 -12 1990 Items[8].Count set value 64b
+
+## Example Item: "Decked Out Crown"
+data modify block -654 -9 1891 Items[0].Count set value 64b
+data modify block -654 -9 1891 Items[1].Count set value 64b
+data modify block -654 -9 1891 Items[2].Count set value 64b
+data modify block -654 -9 1891 Items[3].Count set value 64b
+data modify block -654 -9 1891 Items[4].Count set value 64b
+data modify block -654 -9 1891 Items[5].Count set value 64b
+data modify block -654 -9 1891 Items[6].Count set value 64b
+data modify block -654 -9 1891 Items[7].Count set value 64b
+data modify block -654 -9 1891 Items[8].Count set value 64b
+
+## Example Item: "The Black Mines Key"
+data modify block -503 31 1975 Items[0].Count set value 64b
+data modify block -503 31 1975 Items[1].Count set value 64b
+data modify block -503 31 1975 Items[2].Count set value 64b
+data modify block -503 31 1975 Items[3].Count set value 64b
+data modify block -503 31 1975 Items[4].Count set value 64b
+data modify block -503 31 1975 Items[5].Count set value 64b
+data modify block -503 31 1975 Items[6].Count set value 64b
+data modify block -503 31 1975 Items[7].Count set value 64b
+data modify block -503 31 1975 Items[8].Count set value 64b
+
+## Example Item: "The Black Mines Key"
+data modify block -553 10 2036 Items[0].Count set value 64b
+data modify block -553 10 2036 Items[1].Count set value 64b
+data modify block -553 10 2036 Items[2].Count set value 64b
+data modify block -553 10 2036 Items[3].Count set value 64b
+data modify block -553 10 2036 Items[4].Count set value 64b
+data modify block -553 10 2036 Items[5].Count set value 64b
+data modify block -553 10 2036 Items[6].Count set value 64b
+data modify block -553 10 2036 Items[7].Count set value 64b
+data modify block -553 10 2036 Items[8].Count set value 64b
+
+## Example Item: "The Burning Dark Key"
+data modify block -624 -9 1924 Items[0].Count set value 64b
+data modify block -624 -9 1924 Items[1].Count set value 64b
+data modify block -624 -9 1924 Items[2].Count set value 64b
+data modify block -624 -9 1924 Items[3].Count set value 64b
+data modify block -624 -9 1924 Items[4].Count set value 64b
+data modify block -624 -9 1924 Items[5].Count set value 64b
+data modify block -624 -9 1924 Items[6].Count set value 64b
+data modify block -624 -9 1924 Items[7].Count set value 64b
+data modify block -624 -9 1924 Items[8].Count set value 64b
+
+## Example Item: "The Burning Dark Key"
+data modify block -641 -19 1921 Items[0].Count set value 64b
+data modify block -641 -19 1921 Items[1].Count set value 64b
+data modify block -641 -19 1921 Items[2].Count set value 64b
+data modify block -641 -19 1921 Items[3].Count set value 64b
+data modify block -641 -19 1921 Items[4].Count set value 64b
+data modify block -641 -19 1921 Items[5].Count set value 64b
+data modify block -641 -19 1921 Items[6].Count set value 64b
+data modify block -641 -19 1921 Items[7].Count set value 64b
+data modify block -641 -19 1921 Items[8].Count set value 64b
+
+## Example Item: "The Burning Dark Key"
+data modify block -644 1 1920 Items[0].Count set value 64b
+data modify block -644 1 1920 Items[1].Count set value 64b
+data modify block -644 1 1920 Items[2].Count set value 64b
+data modify block -644 1 1920 Items[3].Count set value 64b
+data modify block -644 1 1920 Items[4].Count set value 64b
+data modify block -644 1 1920 Items[5].Count set value 64b
+data modify block -644 1 1920 Items[6].Count set value 64b
+data modify block -644 1 1920 Items[7].Count set value 64b
+data modify block -644 1 1920 Items[8].Count set value 64b
+
+## Example Item: "The Burning Dark Key"
+data modify block -652 1 1893 Items[0].Count set value 64b
+data modify block -652 1 1893 Items[1].Count set value 64b
+data modify block -652 1 1893 Items[2].Count set value 64b
+data modify block -652 1 1893 Items[3].Count set value 64b
+data modify block -652 1 1893 Items[4].Count set value 64b
+data modify block -652 1 1893 Items[5].Count set value 64b
+data modify block -652 1 1893 Items[6].Count set value 64b
+data modify block -652 1 1893 Items[7].Count set value 64b
+data modify block -652 1 1893 Items[8].Count set value 64b
+
+## Example Item: "The Caves of Carnage Key"
+data modify block -513 37 1992 Items[0].Count set value 64b
+data modify block -513 37 1992 Items[1].Count set value 64b
+data modify block -513 37 1992 Items[2].Count set value 64b
+data modify block -513 37 1992 Items[3].Count set value 64b
+data modify block -513 37 1992 Items[4].Count set value 64b
+data modify block -513 37 1992 Items[5].Count set value 64b
+data modify block -513 37 1992 Items[6].Count set value 64b
+data modify block -513 37 1992 Items[7].Count set value 64b
+data modify block -513 37 1992 Items[8].Count set value 64b
+
+## Example Item: "The Caves of Carnage Key"
+data modify block -518 35 2002 Items[0].Count set value 64b
+data modify block -518 35 2002 Items[1].Count set value 64b
+data modify block -518 35 2002 Items[2].Count set value 64b
+data modify block -518 35 2002 Items[3].Count set value 64b
+data modify block -518 35 2002 Items[4].Count set value 64b
+data modify block -518 35 2002 Items[5].Count set value 64b
+data modify block -518 35 2002 Items[6].Count set value 64b
+data modify block -518 35 2002 Items[7].Count set value 64b
+data modify block -518 35 2002 Items[8].Count set value 64b
+
+## Example Item: "The Caves of Carnage Key"
+data modify block -519 53 2011 Items[0].Count set value 64b
+data modify block -519 53 2011 Items[1].Count set value 64b
+data modify block -519 53 2011 Items[2].Count set value 64b
+data modify block -519 53 2011 Items[3].Count set value 64b
+data modify block -519 53 2011 Items[4].Count set value 64b
+data modify block -519 53 2011 Items[5].Count set value 64b
+data modify block -519 53 2011 Items[6].Count set value 64b
+data modify block -519 53 2011 Items[7].Count set value 64b
+data modify block -519 53 2011 Items[8].Count set value 64b

--- a/Brilliance Datapack/data/do2/functions/dungeon_setup/refill_droppers/all.mcfunction
+++ b/Brilliance Datapack/data/do2/functions/dungeon_setup/refill_droppers/all.mcfunction
@@ -1,3483 +1,956 @@
 # Category "Artifact"
 ## Example Item: "An Old Friend's Pickaxe (38)"
-data modify block -622 -51 1889 Items[0].Count set value 64b
-data modify block -622 -51 1889 Items[1].Count set value 64b
-data modify block -622 -51 1889 Items[2].Count set value 64b
-data modify block -622 -51 1889 Items[3].Count set value 64b
-data modify block -622 -51 1889 Items[4].Count set value 64b
-data modify block -622 -51 1889 Items[5].Count set value 64b
-data modify block -622 -51 1889 Items[6].Count set value 64b
-data modify block -622 -51 1889 Items[7].Count set value 64b
-data modify block -622 -51 1889 Items[8].Count set value 64b
+data modify block -622 -51 1889 Items[].Count set value 64b
 
 ## Example Item: "An Old Friend's Pickaxe (38)"
-data modify block -637 -51 1888 Items[0].Count set value 64b
-data modify block -637 -51 1888 Items[1].Count set value 64b
-data modify block -637 -51 1888 Items[2].Count set value 64b
-data modify block -637 -51 1888 Items[3].Count set value 64b
-data modify block -637 -51 1888 Items[4].Count set value 64b
-data modify block -637 -51 1888 Items[5].Count set value 64b
-data modify block -637 -51 1888 Items[6].Count set value 64b
-data modify block -637 -51 1888 Items[7].Count set value 64b
-data modify block -637 -51 1888 Items[8].Count set value 64b
+data modify block -637 -51 1888 Items[].Count set value 64b
 
 ## Example Item: "An Old Friend's Pickaxe (38)"
-data modify block -659 -14 1922 Items[0].Count set value 64b
-data modify block -659 -14 1922 Items[1].Count set value 64b
-data modify block -659 -14 1922 Items[2].Count set value 64b
-data modify block -659 -14 1922 Items[3].Count set value 64b
-data modify block -659 -14 1922 Items[4].Count set value 64b
-data modify block -659 -14 1922 Items[5].Count set value 64b
-data modify block -659 -14 1922 Items[6].Count set value 64b
-data modify block -659 -14 1922 Items[7].Count set value 64b
-data modify block -659 -14 1922 Items[8].Count set value 64b
+data modify block -659 -14 1922 Items[].Count set value 64b
 
 ## Example Item: "Axe of the Screamin' Void (7)"
-data modify block -548 51 1972 Items[0].Count set value 64b
-data modify block -548 51 1972 Items[1].Count set value 64b
-data modify block -548 51 1972 Items[2].Count set value 64b
-data modify block -548 51 1972 Items[3].Count set value 64b
-data modify block -548 51 1972 Items[4].Count set value 64b
-data modify block -548 51 1972 Items[5].Count set value 64b
-data modify block -548 51 1972 Items[6].Count set value 64b
-data modify block -548 51 1972 Items[7].Count set value 64b
-data modify block -548 51 1972 Items[8].Count set value 64b
+data modify block -548 51 1972 Items[].Count set value 64b
 
 ## Example Item: "Axe of the Screamin' Void (7)"
-data modify block -573 55 1944 Items[0].Count set value 64b
-data modify block -573 55 1944 Items[1].Count set value 64b
-data modify block -573 55 1944 Items[2].Count set value 64b
-data modify block -573 55 1944 Items[3].Count set value 64b
-data modify block -573 55 1944 Items[4].Count set value 64b
-data modify block -573 55 1944 Items[5].Count set value 64b
-data modify block -573 55 1944 Items[6].Count set value 64b
-data modify block -573 55 1944 Items[7].Count set value 64b
-data modify block -573 55 1944 Items[8].Count set value 64b
+data modify block -573 55 1944 Items[].Count set value 64b
 
 ## Example Item: "Axe of the Screamin' Void (7)"
-data modify block -593 49 1967 Items[0].Count set value 64b
-data modify block -593 49 1967 Items[1].Count set value 64b
-data modify block -593 49 1967 Items[2].Count set value 64b
-data modify block -593 49 1967 Items[3].Count set value 64b
-data modify block -593 49 1967 Items[4].Count set value 64b
-data modify block -593 49 1967 Items[5].Count set value 64b
-data modify block -593 49 1967 Items[6].Count set value 64b
-data modify block -593 49 1967 Items[7].Count set value 64b
-data modify block -593 49 1967 Items[8].Count set value 64b
+data modify block -593 49 1967 Items[].Count set value 64b
 
 ## Example Item: "Bionic Eye of Doom (24)"
-data modify block -588 -9 1917 Items[0].Count set value 64b
-data modify block -588 -9 1917 Items[1].Count set value 64b
-data modify block -588 -9 1917 Items[2].Count set value 64b
-data modify block -588 -9 1917 Items[3].Count set value 64b
-data modify block -588 -9 1917 Items[4].Count set value 64b
-data modify block -588 -9 1917 Items[5].Count set value 64b
-data modify block -588 -9 1917 Items[6].Count set value 64b
-data modify block -588 -9 1917 Items[7].Count set value 64b
-data modify block -588 -9 1917 Items[8].Count set value 64b
+data modify block -588 -9 1917 Items[].Count set value 64b
 
 ## Example Item: "Bionic Eye of Doom (24)"
-data modify block -598 1 1890 Items[0].Count set value 64b
-data modify block -598 1 1890 Items[1].Count set value 64b
-data modify block -598 1 1890 Items[2].Count set value 64b
-data modify block -598 1 1890 Items[3].Count set value 64b
-data modify block -598 1 1890 Items[4].Count set value 64b
-data modify block -598 1 1890 Items[5].Count set value 64b
-data modify block -598 1 1890 Items[6].Count set value 64b
-data modify block -598 1 1890 Items[7].Count set value 64b
-data modify block -598 1 1890 Items[8].Count set value 64b
+data modify block -598 1 1890 Items[].Count set value 64b
 
 ## Example Item: "Bionic Eye of Doom (24)"
-data modify block -623 1 1892 Items[0].Count set value 64b
-data modify block -623 1 1892 Items[1].Count set value 64b
-data modify block -623 1 1892 Items[2].Count set value 64b
-data modify block -623 1 1892 Items[3].Count set value 64b
-data modify block -623 1 1892 Items[4].Count set value 64b
-data modify block -623 1 1892 Items[5].Count set value 64b
-data modify block -623 1 1892 Items[6].Count set value 64b
-data modify block -623 1 1892 Items[7].Count set value 64b
-data modify block -623 1 1892 Items[8].Count set value 64b
+data modify block -623 1 1892 Items[].Count set value 64b
 
 ## Example Item: "Butcher's Apron (20)"
-data modify block -519 12 1943 Items[0].Count set value 64b
-data modify block -519 12 1943 Items[1].Count set value 64b
-data modify block -519 12 1943 Items[2].Count set value 64b
-data modify block -519 12 1943 Items[3].Count set value 64b
-data modify block -519 12 1943 Items[4].Count set value 64b
-data modify block -519 12 1943 Items[5].Count set value 64b
-data modify block -519 12 1943 Items[6].Count set value 64b
-data modify block -519 12 1943 Items[7].Count set value 64b
-data modify block -519 12 1943 Items[8].Count set value 64b
+data modify block -519 12 1943 Items[].Count set value 64b
 
 ## Example Item: "Butcher's Apron (20)"
-data modify block -519 12 1982 Items[0].Count set value 64b
-data modify block -519 12 1982 Items[1].Count set value 64b
-data modify block -519 12 1982 Items[2].Count set value 64b
-data modify block -519 12 1982 Items[3].Count set value 64b
-data modify block -519 12 1982 Items[4].Count set value 64b
-data modify block -519 12 1982 Items[5].Count set value 64b
-data modify block -519 12 1982 Items[6].Count set value 64b
-data modify block -519 12 1982 Items[7].Count set value 64b
-data modify block -519 12 1982 Items[8].Count set value 64b
+data modify block -519 12 1982 Items[].Count set value 64b
 
 ## Example Item: "Butcher's Apron (20)"
-data modify block -534 12 1939 Items[0].Count set value 64b
-data modify block -534 12 1939 Items[1].Count set value 64b
-data modify block -534 12 1939 Items[2].Count set value 64b
-data modify block -534 12 1939 Items[3].Count set value 64b
-data modify block -534 12 1939 Items[4].Count set value 64b
-data modify block -534 12 1939 Items[5].Count set value 64b
-data modify block -534 12 1939 Items[6].Count set value 64b
-data modify block -534 12 1939 Items[7].Count set value 64b
-data modify block -534 12 1939 Items[8].Count set value 64b
+data modify block -534 12 1939 Items[].Count set value 64b
 
 ## Example Item: "CF-135 (46)"
-data modify block -574 -48 1910 Items[0].Count set value 64b
-data modify block -574 -48 1910 Items[1].Count set value 64b
-data modify block -574 -48 1910 Items[2].Count set value 64b
-data modify block -574 -48 1910 Items[3].Count set value 64b
-data modify block -574 -48 1910 Items[4].Count set value 64b
-data modify block -574 -48 1910 Items[5].Count set value 64b
-data modify block -574 -48 1910 Items[6].Count set value 64b
-data modify block -574 -48 1910 Items[7].Count set value 64b
-data modify block -574 -48 1910 Items[8].Count set value 64b
+data modify block -574 -48 1910 Items[].Count set value 64b
 
 ## Example Item: "CF-135 (46)"
-data modify block -601 -49 1911 Items[0].Count set value 64b
-data modify block -601 -49 1911 Items[1].Count set value 64b
-data modify block -601 -49 1911 Items[2].Count set value 64b
-data modify block -601 -49 1911 Items[3].Count set value 64b
-data modify block -601 -49 1911 Items[4].Count set value 64b
-data modify block -601 -49 1911 Items[5].Count set value 64b
-data modify block -601 -49 1911 Items[6].Count set value 64b
-data modify block -601 -49 1911 Items[7].Count set value 64b
-data modify block -601 -49 1911 Items[8].Count set value 64b
+data modify block -601 -49 1911 Items[].Count set value 64b
 
 ## Example Item: "CF-135 (46)"
-data modify block -607 -51 1863 Items[0].Count set value 64b
-data modify block -607 -51 1863 Items[1].Count set value 64b
-data modify block -607 -51 1863 Items[2].Count set value 64b
-data modify block -607 -51 1863 Items[3].Count set value 64b
-data modify block -607 -51 1863 Items[4].Count set value 64b
-data modify block -607 -51 1863 Items[5].Count set value 64b
-data modify block -607 -51 1863 Items[6].Count set value 64b
-data modify block -607 -51 1863 Items[7].Count set value 64b
-data modify block -607 -51 1863 Items[8].Count set value 64b
+data modify block -607 -51 1863 Items[].Count set value 64b
 
 ## Example Item: "CF-135 (46)"
-data modify block -623 -52 1856 Items[0].Count set value 64b
-data modify block -623 -52 1856 Items[1].Count set value 64b
-data modify block -623 -52 1856 Items[2].Count set value 64b
-data modify block -623 -52 1856 Items[3].Count set value 64b
-data modify block -623 -52 1856 Items[4].Count set value 64b
-data modify block -623 -52 1856 Items[5].Count set value 64b
-data modify block -623 -52 1856 Items[6].Count set value 64b
-data modify block -623 -52 1856 Items[7].Count set value 64b
-data modify block -623 -52 1856 Items[8].Count set value 64b
+data modify block -623 -52 1856 Items[].Count set value 64b
 
 ## Example Item: "Chisel of the Undead Sculptress (19)"
-data modify block -490 15 2002 Items[0].Count set value 64b
-data modify block -490 15 2002 Items[1].Count set value 64b
-data modify block -490 15 2002 Items[2].Count set value 64b
-data modify block -490 15 2002 Items[3].Count set value 64b
-data modify block -490 15 2002 Items[4].Count set value 64b
-data modify block -490 15 2002 Items[5].Count set value 64b
-data modify block -490 15 2002 Items[6].Count set value 64b
-data modify block -490 15 2002 Items[7].Count set value 64b
-data modify block -490 15 2002 Items[8].Count set value 64b
+data modify block -490 15 2002 Items[].Count set value 64b
 
 ## Example Item: "Chisel of the Undead Sculptress (19)"
-data modify block -537 16 2003 Items[0].Count set value 64b
-data modify block -537 16 2003 Items[1].Count set value 64b
-data modify block -537 16 2003 Items[2].Count set value 64b
-data modify block -537 16 2003 Items[3].Count set value 64b
-data modify block -537 16 2003 Items[4].Count set value 64b
-data modify block -537 16 2003 Items[5].Count set value 64b
-data modify block -537 16 2003 Items[6].Count set value 64b
-data modify block -537 16 2003 Items[7].Count set value 64b
-data modify block -537 16 2003 Items[8].Count set value 64b
+data modify block -537 16 2003 Items[].Count set value 64b
 
 ## Example Item: "Chisel of the Undead Sculptress (19)"
-data modify block -554 10 2024 Items[0].Count set value 64b
-data modify block -554 10 2024 Items[1].Count set value 64b
-data modify block -554 10 2024 Items[2].Count set value 64b
-data modify block -554 10 2024 Items[3].Count set value 64b
-data modify block -554 10 2024 Items[4].Count set value 64b
-data modify block -554 10 2024 Items[5].Count set value 64b
-data modify block -554 10 2024 Items[6].Count set value 64b
-data modify block -554 10 2024 Items[7].Count set value 64b
-data modify block -554 10 2024 Items[8].Count set value 64b
+data modify block -554 10 2024 Items[].Count set value 64b
 
 ## Example Item: "Death Loop (13)"
-data modify block -480 27 1992 Items[0].Count set value 64b
-data modify block -480 27 1992 Items[1].Count set value 64b
-data modify block -480 27 1992 Items[2].Count set value 64b
-data modify block -480 27 1992 Items[3].Count set value 64b
-data modify block -480 27 1992 Items[4].Count set value 64b
-data modify block -480 27 1992 Items[5].Count set value 64b
-data modify block -480 27 1992 Items[6].Count set value 64b
-data modify block -480 27 1992 Items[7].Count set value 64b
-data modify block -480 27 1992 Items[8].Count set value 64b
+data modify block -480 27 1992 Items[].Count set value 64b
 
 ## Example Item: "Death Loop (13)"
-data modify block -505 51 1962 Items[0].Count set value 64b
-data modify block -505 51 1962 Items[1].Count set value 64b
-data modify block -505 51 1962 Items[2].Count set value 64b
-data modify block -505 51 1962 Items[3].Count set value 64b
-data modify block -505 51 1962 Items[4].Count set value 64b
-data modify block -505 51 1962 Items[5].Count set value 64b
-data modify block -505 51 1962 Items[6].Count set value 64b
-data modify block -505 51 1962 Items[7].Count set value 64b
-data modify block -505 51 1962 Items[8].Count set value 64b
+data modify block -505 51 1962 Items[].Count set value 64b
 
 ## Example Item: "Death Loop (13)"
-data modify block -511 52 1958 Items[0].Count set value 64b
-data modify block -511 52 1958 Items[1].Count set value 64b
-data modify block -511 52 1958 Items[2].Count set value 64b
-data modify block -511 52 1958 Items[3].Count set value 64b
-data modify block -511 52 1958 Items[4].Count set value 64b
-data modify block -511 52 1958 Items[5].Count set value 64b
-data modify block -511 52 1958 Items[6].Count set value 64b
-data modify block -511 52 1958 Items[7].Count set value 64b
-data modify block -511 52 1958 Items[8].Count set value 64b
+data modify block -511 52 1958 Items[].Count set value 64b
 
 ## Example Item: "Gem of Greatness (40)"
-data modify block -590 -51 1899 Items[0].Count set value 64b
-data modify block -590 -51 1899 Items[1].Count set value 64b
-data modify block -590 -51 1899 Items[2].Count set value 64b
-data modify block -590 -51 1899 Items[3].Count set value 64b
-data modify block -590 -51 1899 Items[4].Count set value 64b
-data modify block -590 -51 1899 Items[5].Count set value 64b
-data modify block -590 -51 1899 Items[6].Count set value 64b
-data modify block -590 -51 1899 Items[7].Count set value 64b
-data modify block -590 -51 1899 Items[8].Count set value 64b
+data modify block -590 -51 1899 Items[].Count set value 64b
 
 ## Example Item: "Gem of Greatness (40)"
-data modify block -601 -50 1890 Items[0].Count set value 64b
-data modify block -601 -50 1890 Items[1].Count set value 64b
-data modify block -601 -50 1890 Items[2].Count set value 64b
-data modify block -601 -50 1890 Items[3].Count set value 64b
-data modify block -601 -50 1890 Items[4].Count set value 64b
-data modify block -601 -50 1890 Items[5].Count set value 64b
-data modify block -601 -50 1890 Items[6].Count set value 64b
-data modify block -601 -50 1890 Items[7].Count set value 64b
-data modify block -601 -50 1890 Items[8].Count set value 64b
+data modify block -601 -50 1890 Items[].Count set value 64b
 
 ## Example Item: "Golden Eye (34)"
-data modify block -580 -11 1892 Items[0].Count set value 64b
-data modify block -580 -11 1892 Items[1].Count set value 64b
-data modify block -580 -11 1892 Items[2].Count set value 64b
-data modify block -580 -11 1892 Items[3].Count set value 64b
-data modify block -580 -11 1892 Items[4].Count set value 64b
-data modify block -580 -11 1892 Items[5].Count set value 64b
-data modify block -580 -11 1892 Items[6].Count set value 64b
-data modify block -580 -11 1892 Items[7].Count set value 64b
-data modify block -580 -11 1892 Items[8].Count set value 64b
+data modify block -580 -11 1892 Items[].Count set value 64b
 
 ## Example Item: "Golden Eye (34)"
-data modify block -582 -19 1896 Items[0].Count set value 64b
-data modify block -582 -19 1896 Items[1].Count set value 64b
-data modify block -582 -19 1896 Items[2].Count set value 64b
-data modify block -582 -19 1896 Items[3].Count set value 64b
-data modify block -582 -19 1896 Items[4].Count set value 64b
-data modify block -582 -19 1896 Items[5].Count set value 64b
-data modify block -582 -19 1896 Items[6].Count set value 64b
-data modify block -582 -19 1896 Items[7].Count set value 64b
-data modify block -582 -19 1896 Items[8].Count set value 64b
+data modify block -582 -19 1896 Items[].Count set value 64b
 
 ## Example Item: "Golden Eye (34)"
-data modify block -589 -26 1898 Items[0].Count set value 64b
-data modify block -589 -26 1898 Items[1].Count set value 64b
-data modify block -589 -26 1898 Items[2].Count set value 64b
-data modify block -589 -26 1898 Items[3].Count set value 64b
-data modify block -589 -26 1898 Items[4].Count set value 64b
-data modify block -589 -26 1898 Items[5].Count set value 64b
-data modify block -589 -26 1898 Items[6].Count set value 64b
-data modify block -589 -26 1898 Items[7].Count set value 64b
-data modify block -589 -26 1898 Items[8].Count set value 64b
+data modify block -589 -26 1898 Items[].Count set value 64b
 
 ## Example Item: "Hood of Aw'Yah (6)"
-data modify block -513 46 2030 Items[0].Count set value 64b
-data modify block -513 46 2030 Items[1].Count set value 64b
-data modify block -513 46 2030 Items[2].Count set value 64b
-data modify block -513 46 2030 Items[3].Count set value 64b
-data modify block -513 46 2030 Items[4].Count set value 64b
-data modify block -513 46 2030 Items[5].Count set value 64b
-data modify block -513 46 2030 Items[6].Count set value 64b
-data modify block -513 46 2030 Items[7].Count set value 64b
-data modify block -513 46 2030 Items[8].Count set value 64b
+data modify block -513 46 2030 Items[].Count set value 64b
 
 ## Example Item: "Hood of Aw'Yah (6)"
-data modify block -536 46 2035 Items[0].Count set value 64b
-data modify block -536 46 2035 Items[1].Count set value 64b
-data modify block -536 46 2035 Items[2].Count set value 64b
-data modify block -536 46 2035 Items[3].Count set value 64b
-data modify block -536 46 2035 Items[4].Count set value 64b
-data modify block -536 46 2035 Items[5].Count set value 64b
-data modify block -536 46 2035 Items[6].Count set value 64b
-data modify block -536 46 2035 Items[7].Count set value 64b
-data modify block -536 46 2035 Items[8].Count set value 64b
+data modify block -536 46 2035 Items[].Count set value 64b
 
 ## Example Item: "Hood of Aw'Yah (6)"
-data modify block -556 51 2006 Items[0].Count set value 64b
-data modify block -556 51 2006 Items[1].Count set value 64b
-data modify block -556 51 2006 Items[2].Count set value 64b
-data modify block -556 51 2006 Items[3].Count set value 64b
-data modify block -556 51 2006 Items[4].Count set value 64b
-data modify block -556 51 2006 Items[5].Count set value 64b
-data modify block -556 51 2006 Items[6].Count set value 64b
-data modify block -556 51 2006 Items[7].Count set value 64b
-data modify block -556 51 2006 Items[8].Count set value 64b
+data modify block -556 51 2006 Items[].Count set value 64b
 
 ## Example Item: "Hood of Aw'Yah (6)"
-data modify block -562 48 2033 Items[0].Count set value 64b
-data modify block -562 48 2033 Items[1].Count set value 64b
-data modify block -562 48 2033 Items[2].Count set value 64b
-data modify block -562 48 2033 Items[3].Count set value 64b
-data modify block -562 48 2033 Items[4].Count set value 64b
-data modify block -562 48 2033 Items[5].Count set value 64b
-data modify block -562 48 2033 Items[6].Count set value 64b
-data modify block -562 48 2033 Items[7].Count set value 64b
-data modify block -562 48 2033 Items[8].Count set value 64b
+data modify block -562 48 2033 Items[].Count set value 64b
 
 ## Example Item: "Horn of the G.O.A.T. (18)"
-data modify block -487 20 2008 Items[0].Count set value 64b
-data modify block -487 20 2008 Items[1].Count set value 64b
-data modify block -487 20 2008 Items[2].Count set value 64b
-data modify block -487 20 2008 Items[3].Count set value 64b
-data modify block -487 20 2008 Items[4].Count set value 64b
-data modify block -487 20 2008 Items[5].Count set value 64b
-data modify block -487 20 2008 Items[6].Count set value 64b
-data modify block -487 20 2008 Items[7].Count set value 64b
-data modify block -487 20 2008 Items[8].Count set value 64b
+data modify block -487 20 2008 Items[].Count set value 64b
 
 ## Example Item: "Horn of the G.O.A.T. (18)"
-data modify block -503 15 2033 Items[0].Count set value 64b
-data modify block -503 15 2033 Items[1].Count set value 64b
-data modify block -503 15 2033 Items[2].Count set value 64b
-data modify block -503 15 2033 Items[3].Count set value 64b
-data modify block -503 15 2033 Items[4].Count set value 64b
-data modify block -503 15 2033 Items[5].Count set value 64b
-data modify block -503 15 2033 Items[6].Count set value 64b
-data modify block -503 15 2033 Items[7].Count set value 64b
-data modify block -503 15 2033 Items[8].Count set value 64b
+data modify block -503 15 2033 Items[].Count set value 64b
 
 ## Example Item: "Horn of the G.O.A.T. (18)"
-data modify block -520 12 2025 Items[0].Count set value 64b
-data modify block -520 12 2025 Items[1].Count set value 64b
-data modify block -520 12 2025 Items[2].Count set value 64b
-data modify block -520 12 2025 Items[3].Count set value 64b
-data modify block -520 12 2025 Items[4].Count set value 64b
-data modify block -520 12 2025 Items[5].Count set value 64b
-data modify block -520 12 2025 Items[6].Count set value 64b
-data modify block -520 12 2025 Items[7].Count set value 64b
-data modify block -520 12 2025 Items[8].Count set value 64b
+data modify block -520 12 2025 Items[].Count set value 64b
 
 ## Example Item: "Hypnotic Bandana (21)"
-data modify block -572 9 1944 Items[0].Count set value 64b
-data modify block -572 9 1944 Items[1].Count set value 64b
-data modify block -572 9 1944 Items[2].Count set value 64b
-data modify block -572 9 1944 Items[3].Count set value 64b
-data modify block -572 9 1944 Items[4].Count set value 64b
-data modify block -572 9 1944 Items[5].Count set value 64b
-data modify block -572 9 1944 Items[6].Count set value 64b
-data modify block -572 9 1944 Items[7].Count set value 64b
-data modify block -572 9 1944 Items[8].Count set value 64b
+data modify block -572 9 1944 Items[].Count set value 64b
 
 ## Example Item: "Hypnotic Bandana (21)"
-data modify block -573 8 1966 Items[0].Count set value 64b
-data modify block -573 8 1966 Items[1].Count set value 64b
-data modify block -573 8 1966 Items[2].Count set value 64b
-data modify block -573 8 1966 Items[3].Count set value 64b
-data modify block -573 8 1966 Items[4].Count set value 64b
-data modify block -573 8 1966 Items[5].Count set value 64b
-data modify block -573 8 1966 Items[6].Count set value 64b
-data modify block -573 8 1966 Items[7].Count set value 64b
-data modify block -573 8 1966 Items[8].Count set value 64b
+data modify block -573 8 1966 Items[].Count set value 64b
 
 ## Example Item: "Hypnotic Bandana (21)"
-data modify block -588 13 1987 Items[0].Count set value 64b
-data modify block -588 13 1987 Items[1].Count set value 64b
-data modify block -588 13 1987 Items[2].Count set value 64b
-data modify block -588 13 1987 Items[3].Count set value 64b
-data modify block -588 13 1987 Items[4].Count set value 64b
-data modify block -588 13 1987 Items[5].Count set value 64b
-data modify block -588 13 1987 Items[6].Count set value 64b
-data modify block -588 13 1987 Items[7].Count set value 64b
-data modify block -588 13 1987 Items[8].Count set value 64b
+data modify block -588 13 1987 Items[].Count set value 64b
 
 ## Example Item: "Jar of Speedy Slime (11)"
-data modify block -517 52 2006 Items[0].Count set value 64b
-data modify block -517 52 2006 Items[1].Count set value 64b
-data modify block -517 52 2006 Items[2].Count set value 64b
-data modify block -517 52 2006 Items[3].Count set value 64b
-data modify block -517 52 2006 Items[4].Count set value 64b
-data modify block -517 52 2006 Items[5].Count set value 64b
-data modify block -517 52 2006 Items[6].Count set value 64b
-data modify block -517 52 2006 Items[7].Count set value 64b
-data modify block -517 52 2006 Items[8].Count set value 64b
+data modify block -517 52 2006 Items[].Count set value 64b
 
 ## Example Item: "Jar of Speedy Slime (11)"
-data modify block -525 51 1969 Items[0].Count set value 64b
-data modify block -525 51 1969 Items[1].Count set value 64b
-data modify block -525 51 1969 Items[2].Count set value 64b
-data modify block -525 51 1969 Items[3].Count set value 64b
-data modify block -525 51 1969 Items[4].Count set value 64b
-data modify block -525 51 1969 Items[5].Count set value 64b
-data modify block -525 51 1969 Items[6].Count set value 64b
-data modify block -525 51 1969 Items[7].Count set value 64b
-data modify block -525 51 1969 Items[8].Count set value 64b
+data modify block -525 51 1969 Items[].Count set value 64b
 
 ## Example Item: "Jar of Speedy Slime (11)"
-data modify block -543 44 1940 Items[0].Count set value 64b
-data modify block -543 44 1940 Items[1].Count set value 64b
-data modify block -543 44 1940 Items[2].Count set value 64b
-data modify block -543 44 1940 Items[3].Count set value 64b
-data modify block -543 44 1940 Items[4].Count set value 64b
-data modify block -543 44 1940 Items[5].Count set value 64b
-data modify block -543 44 1940 Items[6].Count set value 64b
-data modify block -543 44 1940 Items[7].Count set value 64b
-data modify block -543 44 1940 Items[8].Count set value 64b
+data modify block -543 44 1940 Items[].Count set value 64b
 
 ## Example Item: "Knight's Helm (23)"
-data modify block -571 12 2026 Items[0].Count set value 64b
-data modify block -571 12 2026 Items[1].Count set value 64b
-data modify block -571 12 2026 Items[2].Count set value 64b
-data modify block -571 12 2026 Items[3].Count set value 64b
-data modify block -571 12 2026 Items[4].Count set value 64b
-data modify block -571 12 2026 Items[5].Count set value 64b
-data modify block -571 12 2026 Items[6].Count set value 64b
-data modify block -571 12 2026 Items[7].Count set value 64b
-data modify block -571 12 2026 Items[8].Count set value 64b
+data modify block -571 12 2026 Items[].Count set value 64b
 
 ## Example Item: "Knight's Helm (23)"
-data modify block -574 15 2014 Items[0].Count set value 64b
-data modify block -574 15 2014 Items[1].Count set value 64b
-data modify block -574 15 2014 Items[2].Count set value 64b
-data modify block -574 15 2014 Items[3].Count set value 64b
-data modify block -574 15 2014 Items[4].Count set value 64b
-data modify block -574 15 2014 Items[5].Count set value 64b
-data modify block -574 15 2014 Items[6].Count set value 64b
-data modify block -574 15 2014 Items[7].Count set value 64b
-data modify block -574 15 2014 Items[8].Count set value 64b
+data modify block -574 15 2014 Items[].Count set value 64b
 
 ## Example Item: "Knight's Helm (23)"
-data modify block -599 12 2031 Items[0].Count set value 64b
-data modify block -599 12 2031 Items[1].Count set value 64b
-data modify block -599 12 2031 Items[2].Count set value 64b
-data modify block -599 12 2031 Items[3].Count set value 64b
-data modify block -599 12 2031 Items[4].Count set value 64b
-data modify block -599 12 2031 Items[5].Count set value 64b
-data modify block -599 12 2031 Items[6].Count set value 64b
-data modify block -599 12 2031 Items[7].Count set value 64b
-data modify block -599 12 2031 Items[8].Count set value 64b
+data modify block -599 12 2031 Items[].Count set value 64b
 
 ## Example Item: "Mug of the Dungeon Master (54)"
-data modify block -570 -51 1853 Items[0].Count set value 64b
-data modify block -570 -51 1853 Items[1].Count set value 64b
-data modify block -570 -51 1853 Items[2].Count set value 64b
-data modify block -570 -51 1853 Items[3].Count set value 64b
-data modify block -570 -51 1853 Items[4].Count set value 64b
-data modify block -570 -51 1853 Items[5].Count set value 64b
-data modify block -570 -51 1853 Items[6].Count set value 64b
-data modify block -570 -51 1853 Items[7].Count set value 64b
-data modify block -570 -51 1853 Items[8].Count set value 64b
+data modify block -570 -51 1853 Items[].Count set value 64b
 
 ## Example Item: "Multi-Grain Waffle (8)"
-data modify block -490 50 2020 Items[0].Count set value 64b
-data modify block -490 50 2020 Items[1].Count set value 64b
-data modify block -490 50 2020 Items[2].Count set value 64b
-data modify block -490 50 2020 Items[3].Count set value 64b
-data modify block -490 50 2020 Items[4].Count set value 64b
-data modify block -490 50 2020 Items[5].Count set value 64b
-data modify block -490 50 2020 Items[6].Count set value 64b
-data modify block -490 50 2020 Items[7].Count set value 64b
-data modify block -490 50 2020 Items[8].Count set value 64b
+data modify block -490 50 2020 Items[].Count set value 64b
 
 ## Example Item: "Multi-Grain Waffle (8)"
-data modify block -499 44 2013 Items[0].Count set value 64b
-data modify block -499 44 2013 Items[1].Count set value 64b
-data modify block -499 44 2013 Items[2].Count set value 64b
-data modify block -499 44 2013 Items[3].Count set value 64b
-data modify block -499 44 2013 Items[4].Count set value 64b
-data modify block -499 44 2013 Items[5].Count set value 64b
-data modify block -499 44 2013 Items[6].Count set value 64b
-data modify block -499 44 2013 Items[7].Count set value 64b
-data modify block -499 44 2013 Items[8].Count set value 64b
+data modify block -499 44 2013 Items[].Count set value 64b
 
 ## Example Item: "Multi-Grain Waffle (8)"
-data modify block -546 38 1995 Items[0].Count set value 64b
-data modify block -546 38 1995 Items[1].Count set value 64b
-data modify block -546 38 1995 Items[2].Count set value 64b
-data modify block -546 38 1995 Items[3].Count set value 64b
-data modify block -546 38 1995 Items[4].Count set value 64b
-data modify block -546 38 1995 Items[5].Count set value 64b
-data modify block -546 38 1995 Items[6].Count set value 64b
-data modify block -546 38 1995 Items[7].Count set value 64b
-data modify block -546 38 1995 Items[8].Count set value 64b
+data modify block -546 38 1995 Items[].Count set value 64b
 
 ## Example Item: "Papa's Slippers (10)"
-data modify block -528 45 1956 Items[0].Count set value 64b
-data modify block -528 45 1956 Items[1].Count set value 64b
-data modify block -528 45 1956 Items[2].Count set value 64b
-data modify block -528 45 1956 Items[3].Count set value 64b
-data modify block -528 45 1956 Items[4].Count set value 64b
-data modify block -528 45 1956 Items[5].Count set value 64b
-data modify block -528 45 1956 Items[6].Count set value 64b
-data modify block -528 45 1956 Items[7].Count set value 64b
-data modify block -528 45 1956 Items[8].Count set value 64b
+data modify block -528 45 1956 Items[].Count set value 64b
 
 ## Example Item: "Papa's Slippers (10)"
-data modify block -536 44 1966 Items[0].Count set value 64b
-data modify block -536 44 1966 Items[1].Count set value 64b
-data modify block -536 44 1966 Items[2].Count set value 64b
-data modify block -536 44 1966 Items[3].Count set value 64b
-data modify block -536 44 1966 Items[4].Count set value 64b
-data modify block -536 44 1966 Items[5].Count set value 64b
-data modify block -536 44 1966 Items[6].Count set value 64b
-data modify block -536 44 1966 Items[7].Count set value 64b
-data modify block -536 44 1966 Items[8].Count set value 64b
+data modify block -536 44 1966 Items[].Count set value 64b
 
 ## Example Item: "Papa's Slippers (10)"
-data modify block -552 45 1955 Items[0].Count set value 64b
-data modify block -552 45 1955 Items[1].Count set value 64b
-data modify block -552 45 1955 Items[2].Count set value 64b
-data modify block -552 45 1955 Items[3].Count set value 64b
-data modify block -552 45 1955 Items[4].Count set value 64b
-data modify block -552 45 1955 Items[5].Count set value 64b
-data modify block -552 45 1955 Items[6].Count set value 64b
-data modify block -552 45 1955 Items[7].Count set value 64b
-data modify block -552 45 1955 Items[8].Count set value 64b
+data modify block -552 45 1955 Items[].Count set value 64b
 
 ## Example Item: "Pearl of Cleansing (14)"
-data modify block -452 18 1979 Items[0].Count set value 64b
-data modify block -452 18 1979 Items[1].Count set value 64b
-data modify block -452 18 1979 Items[2].Count set value 64b
-data modify block -452 18 1979 Items[3].Count set value 64b
-data modify block -452 18 1979 Items[4].Count set value 64b
-data modify block -452 18 1979 Items[5].Count set value 64b
-data modify block -452 18 1979 Items[6].Count set value 64b
-data modify block -452 18 1979 Items[7].Count set value 64b
-data modify block -452 18 1979 Items[8].Count set value 64b
+data modify block -452 18 1979 Items[].Count set value 64b
 
 ## Example Item: "Pearl of Cleansing (14)"
-data modify block -475 16 1962 Items[0].Count set value 64b
-data modify block -475 16 1962 Items[1].Count set value 64b
-data modify block -475 16 1962 Items[2].Count set value 64b
-data modify block -475 16 1962 Items[3].Count set value 64b
-data modify block -475 16 1962 Items[4].Count set value 64b
-data modify block -475 16 1962 Items[5].Count set value 64b
-data modify block -475 16 1962 Items[6].Count set value 64b
-data modify block -475 16 1962 Items[7].Count set value 64b
-data modify block -475 16 1962 Items[8].Count set value 64b
+data modify block -475 16 1962 Items[].Count set value 64b
 
 ## Example Item: "Pearl of Cleansing (14)"
-data modify block -484 18 2037 Items[0].Count set value 64b
-data modify block -484 18 2037 Items[1].Count set value 64b
-data modify block -484 18 2037 Items[2].Count set value 64b
-data modify block -484 18 2037 Items[3].Count set value 64b
-data modify block -484 18 2037 Items[4].Count set value 64b
-data modify block -484 18 2037 Items[5].Count set value 64b
-data modify block -484 18 2037 Items[6].Count set value 64b
-data modify block -484 18 2037 Items[7].Count set value 64b
-data modify block -484 18 2037 Items[8].Count set value 64b
+data modify block -484 18 2037 Items[].Count set value 64b
 
 ## Example Item: "Pocket Watch of Shreeping (36)"
-data modify block -598 -7 1881 Items[0].Count set value 64b
-data modify block -598 -7 1881 Items[1].Count set value 64b
-data modify block -598 -7 1881 Items[2].Count set value 64b
-data modify block -598 -7 1881 Items[3].Count set value 64b
-data modify block -598 -7 1881 Items[4].Count set value 64b
-data modify block -598 -7 1881 Items[5].Count set value 64b
-data modify block -598 -7 1881 Items[6].Count set value 64b
-data modify block -598 -7 1881 Items[7].Count set value 64b
-data modify block -598 -7 1881 Items[8].Count set value 64b
+data modify block -598 -7 1881 Items[].Count set value 64b
 
 ## Example Item: "Pocket Watch of Shreeping (36)"
-data modify block -623 -19 1890 Items[0].Count set value 64b
-data modify block -623 -19 1890 Items[1].Count set value 64b
-data modify block -623 -19 1890 Items[2].Count set value 64b
-data modify block -623 -19 1890 Items[3].Count set value 64b
-data modify block -623 -19 1890 Items[4].Count set value 64b
-data modify block -623 -19 1890 Items[5].Count set value 64b
-data modify block -623 -19 1890 Items[6].Count set value 64b
-data modify block -623 -19 1890 Items[7].Count set value 64b
-data modify block -623 -19 1890 Items[8].Count set value 64b
+data modify block -623 -19 1890 Items[].Count set value 64b
 
 ## Example Item: "Pocket Watch of Shreeping (36)"
-data modify block -648 -19 1893 Items[0].Count set value 64b
-data modify block -648 -19 1893 Items[1].Count set value 64b
-data modify block -648 -19 1893 Items[2].Count set value 64b
-data modify block -648 -19 1893 Items[3].Count set value 64b
-data modify block -648 -19 1893 Items[4].Count set value 64b
-data modify block -648 -19 1893 Items[5].Count set value 64b
-data modify block -648 -19 1893 Items[6].Count set value 64b
-data modify block -648 -19 1893 Items[7].Count set value 64b
-data modify block -648 -19 1893 Items[8].Count set value 64b
+data modify block -648 -19 1893 Items[].Count set value 64b
 
 ## Example Item: "Shades of the Dog (9)"
-data modify block -517 35 1984 Items[0].Count set value 64b
-data modify block -517 35 1984 Items[1].Count set value 64b
-data modify block -517 35 1984 Items[2].Count set value 64b
-data modify block -517 35 1984 Items[3].Count set value 64b
-data modify block -517 35 1984 Items[4].Count set value 64b
-data modify block -517 35 1984 Items[5].Count set value 64b
-data modify block -517 35 1984 Items[6].Count set value 64b
-data modify block -517 35 1984 Items[7].Count set value 64b
-data modify block -517 35 1984 Items[8].Count set value 64b
+data modify block -517 35 1984 Items[].Count set value 64b
 
 ## Example Item: "Shades of the Dog (9)"
-data modify block -520 35 2000 Items[0].Count set value 64b
-data modify block -520 35 2000 Items[1].Count set value 64b
-data modify block -520 35 2000 Items[2].Count set value 64b
-data modify block -520 35 2000 Items[3].Count set value 64b
-data modify block -520 35 2000 Items[4].Count set value 64b
-data modify block -520 35 2000 Items[5].Count set value 64b
-data modify block -520 35 2000 Items[6].Count set value 64b
-data modify block -520 35 2000 Items[7].Count set value 64b
-data modify block -520 35 2000 Items[8].Count set value 64b
+data modify block -520 35 2000 Items[].Count set value 64b
 
 ## Example Item: "Shades of the Dog (9)"
-data modify block -550 38 1984 Items[0].Count set value 64b
-data modify block -550 38 1984 Items[1].Count set value 64b
-data modify block -550 38 1984 Items[2].Count set value 64b
-data modify block -550 38 1984 Items[3].Count set value 64b
-data modify block -550 38 1984 Items[4].Count set value 64b
-data modify block -550 38 1984 Items[5].Count set value 64b
-data modify block -550 38 1984 Items[6].Count set value 64b
-data modify block -550 38 1984 Items[7].Count set value 64b
-data modify block -550 38 1984 Items[8].Count set value 64b
+data modify block -550 38 1984 Items[].Count set value 64b
 
 ## Example Item: "Staff of the Pink Shepherd (48)"
-data modify block -599 -51 1842 Items[0].Count set value 64b
-data modify block -599 -51 1842 Items[1].Count set value 64b
-data modify block -599 -51 1842 Items[2].Count set value 64b
-data modify block -599 -51 1842 Items[3].Count set value 64b
-data modify block -599 -51 1842 Items[4].Count set value 64b
-data modify block -599 -51 1842 Items[5].Count set value 64b
-data modify block -599 -51 1842 Items[6].Count set value 64b
-data modify block -599 -51 1842 Items[7].Count set value 64b
-data modify block -599 -51 1842 Items[8].Count set value 64b
+data modify block -599 -51 1842 Items[].Count set value 64b
 
 ## Example Item: "Staff of the Pink Shepherd (48)"
-data modify block -600 -51 1851 Items[0].Count set value 64b
-data modify block -600 -51 1851 Items[1].Count set value 64b
-data modify block -600 -51 1851 Items[2].Count set value 64b
-data modify block -600 -51 1851 Items[3].Count set value 64b
-data modify block -600 -51 1851 Items[4].Count set value 64b
-data modify block -600 -51 1851 Items[5].Count set value 64b
-data modify block -600 -51 1851 Items[6].Count set value 64b
-data modify block -600 -51 1851 Items[7].Count set value 64b
-data modify block -600 -51 1851 Items[8].Count set value 64b
+data modify block -600 -51 1851 Items[].Count set value 64b
 
 ## Example Item: "Staff of the Pink Shepherd (48)"
-data modify block -623 -54 1842 Items[0].Count set value 64b
-data modify block -623 -54 1842 Items[1].Count set value 64b
-data modify block -623 -54 1842 Items[2].Count set value 64b
-data modify block -623 -54 1842 Items[3].Count set value 64b
-data modify block -623 -54 1842 Items[4].Count set value 64b
-data modify block -623 -54 1842 Items[5].Count set value 64b
-data modify block -623 -54 1842 Items[6].Count set value 64b
-data modify block -623 -54 1842 Items[7].Count set value 64b
-data modify block -623 -54 1842 Items[8].Count set value 64b
+data modify block -623 -54 1842 Items[].Count set value 64b
 
 ## Example Item: "The Hidden Stache (30)"
-data modify block -604 -9 1914 Items[0].Count set value 64b
-data modify block -604 -9 1914 Items[1].Count set value 64b
-data modify block -604 -9 1914 Items[2].Count set value 64b
-data modify block -604 -9 1914 Items[3].Count set value 64b
-data modify block -604 -9 1914 Items[4].Count set value 64b
-data modify block -604 -9 1914 Items[5].Count set value 64b
-data modify block -604 -9 1914 Items[6].Count set value 64b
-data modify block -604 -9 1914 Items[7].Count set value 64b
-data modify block -604 -9 1914 Items[8].Count set value 64b
+data modify block -604 -9 1914 Items[].Count set value 64b
 
 ## Example Item: "The Hidden Stache (30)"
-data modify block -635 -9 1890 Items[0].Count set value 64b
-data modify block -635 -9 1890 Items[1].Count set value 64b
-data modify block -635 -9 1890 Items[2].Count set value 64b
-data modify block -635 -9 1890 Items[3].Count set value 64b
-data modify block -635 -9 1890 Items[4].Count set value 64b
-data modify block -635 -9 1890 Items[5].Count set value 64b
-data modify block -635 -9 1890 Items[6].Count set value 64b
-data modify block -635 -9 1890 Items[7].Count set value 64b
-data modify block -635 -9 1890 Items[8].Count set value 64b
+data modify block -635 -9 1890 Items[].Count set value 64b
 
 ## Example Item: "The Hidden Stache (30)"
-data modify block -651 1 1916 Items[0].Count set value 64b
-data modify block -651 1 1916 Items[1].Count set value 64b
-data modify block -651 1 1916 Items[2].Count set value 64b
-data modify block -651 1 1916 Items[3].Count set value 64b
-data modify block -651 1 1916 Items[4].Count set value 64b
-data modify block -651 1 1916 Items[5].Count set value 64b
-data modify block -651 1 1916 Items[6].Count set value 64b
-data modify block -651 1 1916 Items[7].Count set value 64b
-data modify block -651 1 1916 Items[8].Count set value 64b
+data modify block -651 1 1916 Items[].Count set value 64b
 
 ## Example Item: "The Master's Key (60)"
-data modify block -603 -60 1886 Items[0].Count set value 64b
-data modify block -603 -60 1886 Items[1].Count set value 64b
-data modify block -603 -60 1886 Items[2].Count set value 64b
-data modify block -603 -60 1886 Items[3].Count set value 64b
-data modify block -603 -60 1886 Items[4].Count set value 64b
-data modify block -603 -60 1886 Items[5].Count set value 64b
-data modify block -603 -60 1886 Items[6].Count set value 64b
-data modify block -603 -60 1886 Items[7].Count set value 64b
-data modify block -603 -60 1886 Items[8].Count set value 64b
+data modify block -603 -60 1886 Items[].Count set value 64b
 
 ## Example Item: "The Skadoodler (52)"
-data modify block -590 -51 1864 Items[0].Count set value 64b
-data modify block -590 -51 1864 Items[1].Count set value 64b
-data modify block -590 -51 1864 Items[2].Count set value 64b
-data modify block -590 -51 1864 Items[3].Count set value 64b
-data modify block -590 -51 1864 Items[4].Count set value 64b
-data modify block -590 -51 1864 Items[5].Count set value 64b
-data modify block -590 -51 1864 Items[6].Count set value 64b
-data modify block -590 -51 1864 Items[7].Count set value 64b
-data modify block -590 -51 1864 Items[8].Count set value 64b
+data modify block -590 -51 1864 Items[].Count set value 64b
 
 ## Example Item: "The Skadoodler (52)"
-data modify block -635 -51 1877 Items[0].Count set value 64b
-data modify block -635 -51 1877 Items[1].Count set value 64b
-data modify block -635 -51 1877 Items[2].Count set value 64b
-data modify block -635 -51 1877 Items[3].Count set value 64b
-data modify block -635 -51 1877 Items[4].Count set value 64b
-data modify block -635 -51 1877 Items[5].Count set value 64b
-data modify block -635 -51 1877 Items[6].Count set value 64b
-data modify block -635 -51 1877 Items[7].Count set value 64b
-data modify block -635 -51 1877 Items[8].Count set value 64b
+data modify block -635 -51 1877 Items[].Count set value 64b
 
 ## Example Item: "The Skadoodler (52)"
-data modify block -636 -56 1842 Items[0].Count set value 64b
-data modify block -636 -56 1842 Items[1].Count set value 64b
-data modify block -636 -56 1842 Items[2].Count set value 64b
-data modify block -636 -56 1842 Items[3].Count set value 64b
-data modify block -636 -56 1842 Items[4].Count set value 64b
-data modify block -636 -56 1842 Items[5].Count set value 64b
-data modify block -636 -56 1842 Items[6].Count set value 64b
-data modify block -636 -56 1842 Items[7].Count set value 64b
-data modify block -636 -56 1842 Items[8].Count set value 64b
+data modify block -636 -56 1842 Items[].Count set value 64b
 
 ## Example Item: "The Slab (50)"
-data modify block -568 -51 1878 Items[0].Count set value 64b
-data modify block -568 -51 1878 Items[1].Count set value 64b
-data modify block -568 -51 1878 Items[2].Count set value 64b
-data modify block -568 -51 1878 Items[3].Count set value 64b
-data modify block -568 -51 1878 Items[4].Count set value 64b
-data modify block -568 -51 1878 Items[5].Count set value 64b
-data modify block -568 -51 1878 Items[6].Count set value 64b
-data modify block -568 -51 1878 Items[7].Count set value 64b
-data modify block -568 -51 1878 Items[8].Count set value 64b
+data modify block -568 -51 1878 Items[].Count set value 64b
 
 ## Example Item: "The Slab (50)"
-data modify block -569 -51 1884 Items[0].Count set value 64b
-data modify block -569 -51 1884 Items[1].Count set value 64b
-data modify block -569 -51 1884 Items[2].Count set value 64b
-data modify block -569 -51 1884 Items[3].Count set value 64b
-data modify block -569 -51 1884 Items[4].Count set value 64b
-data modify block -569 -51 1884 Items[5].Count set value 64b
-data modify block -569 -51 1884 Items[6].Count set value 64b
-data modify block -569 -51 1884 Items[7].Count set value 64b
-data modify block -569 -51 1884 Items[8].Count set value 64b
+data modify block -569 -51 1884 Items[].Count set value 64b
 
 ## Example Item: "The Slab (50)"
-data modify block -591 -51 1870 Items[0].Count set value 64b
-data modify block -591 -51 1870 Items[1].Count set value 64b
-data modify block -591 -51 1870 Items[2].Count set value 64b
-data modify block -591 -51 1870 Items[3].Count set value 64b
-data modify block -591 -51 1870 Items[4].Count set value 64b
-data modify block -591 -51 1870 Items[5].Count set value 64b
-data modify block -591 -51 1870 Items[6].Count set value 64b
-data modify block -591 -51 1870 Items[7].Count set value 64b
-data modify block -591 -51 1870 Items[8].Count set value 64b
+data modify block -591 -51 1870 Items[].Count set value 64b
 
 ## Example Item: "Tome of the Hills (12)"
-data modify block -497 51 1995 Items[0].Count set value 64b
-data modify block -497 51 1995 Items[1].Count set value 64b
-data modify block -497 51 1995 Items[2].Count set value 64b
-data modify block -497 51 1995 Items[3].Count set value 64b
-data modify block -497 51 1995 Items[4].Count set value 64b
-data modify block -497 51 1995 Items[5].Count set value 64b
-data modify block -497 51 1995 Items[6].Count set value 64b
-data modify block -497 51 1995 Items[7].Count set value 64b
-data modify block -497 51 1995 Items[8].Count set value 64b
+data modify block -497 51 1995 Items[].Count set value 64b
 
 ## Example Item: "Tome of the Hills (12)"
-data modify block -505 51 1981 Items[0].Count set value 64b
-data modify block -505 51 1981 Items[1].Count set value 64b
-data modify block -505 51 1981 Items[2].Count set value 64b
-data modify block -505 51 1981 Items[3].Count set value 64b
-data modify block -505 51 1981 Items[4].Count set value 64b
-data modify block -505 51 1981 Items[5].Count set value 64b
-data modify block -505 51 1981 Items[6].Count set value 64b
-data modify block -505 51 1981 Items[7].Count set value 64b
-data modify block -505 51 1981 Items[8].Count set value 64b
+data modify block -505 51 1981 Items[].Count set value 64b
 
 ## Example Item: "Tome of the Hills (12)"
-data modify block -543 51 2016 Items[0].Count set value 64b
-data modify block -543 51 2016 Items[1].Count set value 64b
-data modify block -543 51 2016 Items[2].Count set value 64b
-data modify block -543 51 2016 Items[3].Count set value 64b
-data modify block -543 51 2016 Items[4].Count set value 64b
-data modify block -543 51 2016 Items[5].Count set value 64b
-data modify block -543 51 2016 Items[6].Count set value 64b
-data modify block -543 51 2016 Items[7].Count set value 64b
-data modify block -543 51 2016 Items[8].Count set value 64b
+data modify block -543 51 2016 Items[].Count set value 64b
 
 ## Example Item: "Wand of Gorgeousness (22)"
-data modify block -505 23 1958 Items[0].Count set value 64b
-data modify block -505 23 1958 Items[1].Count set value 64b
-data modify block -505 23 1958 Items[2].Count set value 64b
-data modify block -505 23 1958 Items[3].Count set value 64b
-data modify block -505 23 1958 Items[4].Count set value 64b
-data modify block -505 23 1958 Items[5].Count set value 64b
-data modify block -505 23 1958 Items[6].Count set value 64b
-data modify block -505 23 1958 Items[7].Count set value 64b
-data modify block -505 23 1958 Items[8].Count set value 64b
+data modify block -505 23 1958 Items[].Count set value 64b
 
 ## Example Item: "Wand of Gorgeousness (22)"
-data modify block -549 10 1969 Items[0].Count set value 64b
-data modify block -549 10 1969 Items[1].Count set value 64b
-data modify block -549 10 1969 Items[2].Count set value 64b
-data modify block -549 10 1969 Items[3].Count set value 64b
-data modify block -549 10 1969 Items[4].Count set value 64b
-data modify block -549 10 1969 Items[5].Count set value 64b
-data modify block -549 10 1969 Items[6].Count set value 64b
-data modify block -549 10 1969 Items[7].Count set value 64b
-data modify block -549 10 1969 Items[8].Count set value 64b
+data modify block -549 10 1969 Items[].Count set value 64b
 
 ## Example Item: "Wand of Gorgeousness (22)"
-data modify block -575 13 1994 Items[0].Count set value 64b
-data modify block -575 13 1994 Items[1].Count set value 64b
-data modify block -575 13 1994 Items[2].Count set value 64b
-data modify block -575 13 1994 Items[3].Count set value 64b
-data modify block -575 13 1994 Items[4].Count set value 64b
-data modify block -575 13 1994 Items[5].Count set value 64b
-data modify block -575 13 1994 Items[6].Count set value 64b
-data modify block -575 13 1994 Items[7].Count set value 64b
-data modify block -575 13 1994 Items[8].Count set value 64b
+data modify block -575 13 1994 Items[].Count set value 64b
 
 # Category "Artifakes"
 ## Example Item: "An Old Friend's Pickaxe"
-data modify block -641 -23 1958 Items[0].Count set value 64b
-data modify block -641 -23 1958 Items[1].Count set value 64b
-data modify block -641 -23 1958 Items[2].Count set value 64b
-data modify block -641 -23 1958 Items[3].Count set value 64b
-data modify block -641 -23 1958 Items[4].Count set value 64b
-data modify block -641 -23 1958 Items[5].Count set value 64b
-data modify block -641 -23 1958 Items[6].Count set value 64b
-data modify block -641 -23 1958 Items[7].Count set value 64b
-data modify block -641 -23 1958 Items[8].Count set value 64b
+data modify block -641 -23 1958 Items[].Count set value 64b
 
 ## Example Item: "Axe of the Screamin' Void"
-data modify block -641 -23 1977 Items[0].Count set value 64b
-data modify block -641 -23 1977 Items[1].Count set value 64b
-data modify block -641 -23 1977 Items[2].Count set value 64b
-data modify block -641 -23 1977 Items[3].Count set value 64b
-data modify block -641 -23 1977 Items[4].Count set value 64b
-data modify block -641 -23 1977 Items[5].Count set value 64b
-data modify block -641 -23 1977 Items[6].Count set value 64b
-data modify block -641 -23 1977 Items[7].Count set value 64b
-data modify block -641 -23 1977 Items[8].Count set value 64b
+data modify block -641 -23 1977 Items[].Count set value 64b
 
 ## Example Item: "Bionic Eye of Doom"
-data modify block -641 -23 1963 Items[0].Count set value 64b
-data modify block -641 -23 1963 Items[1].Count set value 64b
-data modify block -641 -23 1963 Items[2].Count set value 64b
-data modify block -641 -23 1963 Items[3].Count set value 64b
-data modify block -641 -23 1963 Items[4].Count set value 64b
-data modify block -641 -23 1963 Items[5].Count set value 64b
-data modify block -641 -23 1963 Items[6].Count set value 64b
-data modify block -641 -23 1963 Items[7].Count set value 64b
-data modify block -641 -23 1963 Items[8].Count set value 64b
+data modify block -641 -23 1963 Items[].Count set value 64b
 
 ## Example Item: "Butcher's Apron"
-data modify block -641 -23 1967 Items[0].Count set value 64b
-data modify block -641 -23 1967 Items[1].Count set value 64b
-data modify block -641 -23 1967 Items[2].Count set value 64b
-data modify block -641 -23 1967 Items[3].Count set value 64b
-data modify block -641 -23 1967 Items[4].Count set value 64b
-data modify block -641 -23 1967 Items[5].Count set value 64b
-data modify block -641 -23 1967 Items[6].Count set value 64b
-data modify block -641 -23 1967 Items[7].Count set value 64b
-data modify block -641 -23 1967 Items[8].Count set value 64b
+data modify block -641 -23 1967 Items[].Count set value 64b
 
 ## Example Item: "CF-135"
-data modify block -641 -23 1956 Items[0].Count set value 64b
-data modify block -641 -23 1956 Items[1].Count set value 64b
-data modify block -641 -23 1956 Items[2].Count set value 64b
-data modify block -641 -23 1956 Items[3].Count set value 64b
-data modify block -641 -23 1956 Items[4].Count set value 64b
-data modify block -641 -23 1956 Items[5].Count set value 64b
-data modify block -641 -23 1956 Items[6].Count set value 64b
-data modify block -641 -23 1956 Items[7].Count set value 64b
-data modify block -641 -23 1956 Items[8].Count set value 64b
+data modify block -641 -23 1956 Items[].Count set value 64b
 
 ## Example Item: "Chisel of the Undead Sculptress"
-data modify block -641 -23 1968 Items[0].Count set value 64b
-data modify block -641 -23 1968 Items[1].Count set value 64b
-data modify block -641 -23 1968 Items[2].Count set value 64b
-data modify block -641 -23 1968 Items[3].Count set value 64b
-data modify block -641 -23 1968 Items[4].Count set value 64b
-data modify block -641 -23 1968 Items[5].Count set value 64b
-data modify block -641 -23 1968 Items[6].Count set value 64b
-data modify block -641 -23 1968 Items[7].Count set value 64b
-data modify block -641 -23 1968 Items[8].Count set value 64b
+data modify block -641 -23 1968 Items[].Count set value 64b
 
 ## Example Item: "Death Loop"
-data modify block -641 -23 1971 Items[0].Count set value 64b
-data modify block -641 -23 1971 Items[1].Count set value 64b
-data modify block -641 -23 1971 Items[2].Count set value 64b
-data modify block -641 -23 1971 Items[3].Count set value 64b
-data modify block -641 -23 1971 Items[4].Count set value 64b
-data modify block -641 -23 1971 Items[5].Count set value 64b
-data modify block -641 -23 1971 Items[6].Count set value 64b
-data modify block -641 -23 1971 Items[7].Count set value 64b
-data modify block -641 -23 1971 Items[8].Count set value 64b
+data modify block -641 -23 1971 Items[].Count set value 64b
 
 ## Example Item: "Gem of Greatness"
-data modify block -641 -23 1957 Items[0].Count set value 64b
-data modify block -641 -23 1957 Items[1].Count set value 64b
-data modify block -641 -23 1957 Items[2].Count set value 64b
-data modify block -641 -23 1957 Items[3].Count set value 64b
-data modify block -641 -23 1957 Items[4].Count set value 64b
-data modify block -641 -23 1957 Items[5].Count set value 64b
-data modify block -641 -23 1957 Items[6].Count set value 64b
-data modify block -641 -23 1957 Items[7].Count set value 64b
-data modify block -641 -23 1957 Items[8].Count set value 64b
+data modify block -641 -23 1957 Items[].Count set value 64b
 
 ## Example Item: "Goggles of Symmetry"
-data modify block -641 -23 1961 Items[0].Count set value 64b
-data modify block -641 -23 1961 Items[1].Count set value 64b
-data modify block -641 -23 1961 Items[2].Count set value 64b
-data modify block -641 -23 1961 Items[3].Count set value 64b
-data modify block -641 -23 1961 Items[4].Count set value 64b
-data modify block -641 -23 1961 Items[5].Count set value 64b
-data modify block -641 -23 1961 Items[6].Count set value 64b
-data modify block -641 -23 1961 Items[7].Count set value 64b
-data modify block -641 -23 1961 Items[8].Count set value 64b
+data modify block -641 -23 1961 Items[].Count set value 64b
 
 ## Example Item: "Golden Eye"
-data modify block -641 -23 1960 Items[0].Count set value 64b
-data modify block -641 -23 1960 Items[1].Count set value 64b
-data modify block -641 -23 1960 Items[2].Count set value 64b
-data modify block -641 -23 1960 Items[3].Count set value 64b
-data modify block -641 -23 1960 Items[4].Count set value 64b
-data modify block -641 -23 1960 Items[5].Count set value 64b
-data modify block -641 -23 1960 Items[6].Count set value 64b
-data modify block -641 -23 1960 Items[7].Count set value 64b
-data modify block -641 -23 1960 Items[8].Count set value 64b
+data modify block -641 -23 1960 Items[].Count set value 64b
 
 ## Example Item: "Hood of Aw'Yah"
-data modify block -641 -23 1978 Items[0].Count set value 64b
-data modify block -641 -23 1978 Items[1].Count set value 64b
-data modify block -641 -23 1978 Items[2].Count set value 64b
-data modify block -641 -23 1978 Items[3].Count set value 64b
-data modify block -641 -23 1978 Items[4].Count set value 64b
-data modify block -641 -23 1978 Items[5].Count set value 64b
-data modify block -641 -23 1978 Items[6].Count set value 64b
-data modify block -641 -23 1978 Items[7].Count set value 64b
-data modify block -641 -23 1978 Items[8].Count set value 64b
+data modify block -641 -23 1978 Items[].Count set value 64b
 
 ## Example Item: "Horn of the G.O.A.T."
-data modify block -641 -23 1969 Items[0].Count set value 64b
-data modify block -641 -23 1969 Items[1].Count set value 64b
-data modify block -641 -23 1969 Items[2].Count set value 64b
-data modify block -641 -23 1969 Items[3].Count set value 64b
-data modify block -641 -23 1969 Items[4].Count set value 64b
-data modify block -641 -23 1969 Items[5].Count set value 64b
-data modify block -641 -23 1969 Items[6].Count set value 64b
-data modify block -641 -23 1969 Items[7].Count set value 64b
-data modify block -641 -23 1969 Items[8].Count set value 64b
+data modify block -641 -23 1969 Items[].Count set value 64b
 
 ## Example Item: "Hypnotic Bandana"
-data modify block -641 -23 1966 Items[0].Count set value 64b
-data modify block -641 -23 1966 Items[1].Count set value 64b
-data modify block -641 -23 1966 Items[2].Count set value 64b
-data modify block -641 -23 1966 Items[3].Count set value 64b
-data modify block -641 -23 1966 Items[4].Count set value 64b
-data modify block -641 -23 1966 Items[5].Count set value 64b
-data modify block -641 -23 1966 Items[6].Count set value 64b
-data modify block -641 -23 1966 Items[7].Count set value 64b
-data modify block -641 -23 1966 Items[8].Count set value 64b
+data modify block -641 -23 1966 Items[].Count set value 64b
 
 ## Example Item: "Jar of Speedy Slime"
-data modify block -641 -23 1973 Items[0].Count set value 64b
-data modify block -641 -23 1973 Items[1].Count set value 64b
-data modify block -641 -23 1973 Items[2].Count set value 64b
-data modify block -641 -23 1973 Items[3].Count set value 64b
-data modify block -641 -23 1973 Items[4].Count set value 64b
-data modify block -641 -23 1973 Items[5].Count set value 64b
-data modify block -641 -23 1973 Items[6].Count set value 64b
-data modify block -641 -23 1973 Items[7].Count set value 64b
-data modify block -641 -23 1973 Items[8].Count set value 64b
+data modify block -641 -23 1973 Items[].Count set value 64b
 
 ## Example Item: "Knight's Helm"
-data modify block -641 -23 1964 Items[0].Count set value 64b
-data modify block -641 -23 1964 Items[1].Count set value 64b
-data modify block -641 -23 1964 Items[2].Count set value 64b
-data modify block -641 -23 1964 Items[3].Count set value 64b
-data modify block -641 -23 1964 Items[4].Count set value 64b
-data modify block -641 -23 1964 Items[5].Count set value 64b
-data modify block -641 -23 1964 Items[6].Count set value 64b
-data modify block -641 -23 1964 Items[7].Count set value 64b
-data modify block -641 -23 1964 Items[8].Count set value 64b
+data modify block -641 -23 1964 Items[].Count set value 64b
 
 ## Example Item: "Mug of the Dungeon Master"
-data modify block -641 -23 1952 Items[0].Count set value 64b
-data modify block -641 -23 1952 Items[1].Count set value 64b
-data modify block -641 -23 1952 Items[2].Count set value 64b
-data modify block -641 -23 1952 Items[3].Count set value 64b
-data modify block -641 -23 1952 Items[4].Count set value 64b
-data modify block -641 -23 1952 Items[5].Count set value 64b
-data modify block -641 -23 1952 Items[6].Count set value 64b
-data modify block -641 -23 1952 Items[7].Count set value 64b
-data modify block -641 -23 1952 Items[8].Count set value 64b
+data modify block -641 -23 1952 Items[].Count set value 64b
 
 ## Example Item: "Multi-Grain Waffle"
-data modify block -641 -23 1976 Items[0].Count set value 64b
-data modify block -641 -23 1976 Items[1].Count set value 64b
-data modify block -641 -23 1976 Items[2].Count set value 64b
-data modify block -641 -23 1976 Items[3].Count set value 64b
-data modify block -641 -23 1976 Items[4].Count set value 64b
-data modify block -641 -23 1976 Items[5].Count set value 64b
-data modify block -641 -23 1976 Items[6].Count set value 64b
-data modify block -641 -23 1976 Items[7].Count set value 64b
-data modify block -641 -23 1976 Items[8].Count set value 64b
+data modify block -641 -23 1976 Items[].Count set value 64b
 
 ## Example Item: "Papa's Slippers"
-data modify block -641 -23 1974 Items[0].Count set value 64b
-data modify block -641 -23 1974 Items[1].Count set value 64b
-data modify block -641 -23 1974 Items[2].Count set value 64b
-data modify block -641 -23 1974 Items[3].Count set value 64b
-data modify block -641 -23 1974 Items[4].Count set value 64b
-data modify block -641 -23 1974 Items[5].Count set value 64b
-data modify block -641 -23 1974 Items[6].Count set value 64b
-data modify block -641 -23 1974 Items[7].Count set value 64b
-data modify block -641 -23 1974 Items[8].Count set value 64b
+data modify block -641 -23 1974 Items[].Count set value 64b
 
 ## Example Item: "Pearl of Cleansing"
-data modify block -641 -23 1970 Items[0].Count set value 64b
-data modify block -641 -23 1970 Items[1].Count set value 64b
-data modify block -641 -23 1970 Items[2].Count set value 64b
-data modify block -641 -23 1970 Items[3].Count set value 64b
-data modify block -641 -23 1970 Items[4].Count set value 64b
-data modify block -641 -23 1970 Items[5].Count set value 64b
-data modify block -641 -23 1970 Items[6].Count set value 64b
-data modify block -641 -23 1970 Items[7].Count set value 64b
-data modify block -641 -23 1970 Items[8].Count set value 64b
+data modify block -641 -23 1970 Items[].Count set value 64b
 
 ## Example Item: "Pocket Watch of Shreeping"
-data modify block -641 -23 1959 Items[0].Count set value 64b
-data modify block -641 -23 1959 Items[1].Count set value 64b
-data modify block -641 -23 1959 Items[2].Count set value 64b
-data modify block -641 -23 1959 Items[3].Count set value 64b
-data modify block -641 -23 1959 Items[4].Count set value 64b
-data modify block -641 -23 1959 Items[5].Count set value 64b
-data modify block -641 -23 1959 Items[6].Count set value 64b
-data modify block -641 -23 1959 Items[7].Count set value 64b
-data modify block -641 -23 1959 Items[8].Count set value 64b
+data modify block -641 -23 1959 Items[].Count set value 64b
 
 ## Example Item: "Shades of the Dog"
-data modify block -641 -23 1975 Items[0].Count set value 64b
-data modify block -641 -23 1975 Items[1].Count set value 64b
-data modify block -641 -23 1975 Items[2].Count set value 64b
-data modify block -641 -23 1975 Items[3].Count set value 64b
-data modify block -641 -23 1975 Items[4].Count set value 64b
-data modify block -641 -23 1975 Items[5].Count set value 64b
-data modify block -641 -23 1975 Items[6].Count set value 64b
-data modify block -641 -23 1975 Items[7].Count set value 64b
-data modify block -641 -23 1975 Items[8].Count set value 64b
+data modify block -641 -23 1975 Items[].Count set value 64b
 
 ## Example Item: "Staff of the Pink Shepherd"
-data modify block -641 -23 1955 Items[0].Count set value 64b
-data modify block -641 -23 1955 Items[1].Count set value 64b
-data modify block -641 -23 1955 Items[2].Count set value 64b
-data modify block -641 -23 1955 Items[3].Count set value 64b
-data modify block -641 -23 1955 Items[4].Count set value 64b
-data modify block -641 -23 1955 Items[5].Count set value 64b
-data modify block -641 -23 1955 Items[6].Count set value 64b
-data modify block -641 -23 1955 Items[7].Count set value 64b
-data modify block -641 -23 1955 Items[8].Count set value 64b
+data modify block -641 -23 1955 Items[].Count set value 64b
 
 ## Example Item: "The Hidden Stache"
-data modify block -641 -23 1962 Items[0].Count set value 64b
-data modify block -641 -23 1962 Items[1].Count set value 64b
-data modify block -641 -23 1962 Items[2].Count set value 64b
-data modify block -641 -23 1962 Items[3].Count set value 64b
-data modify block -641 -23 1962 Items[4].Count set value 64b
-data modify block -641 -23 1962 Items[5].Count set value 64b
-data modify block -641 -23 1962 Items[6].Count set value 64b
-data modify block -641 -23 1962 Items[7].Count set value 64b
-data modify block -641 -23 1962 Items[8].Count set value 64b
+data modify block -641 -23 1962 Items[].Count set value 64b
 
 ## Example Item: "The Master's Key"
-data modify block -641 -23 1951 Items[0].Count set value 64b
-data modify block -641 -23 1951 Items[1].Count set value 64b
-data modify block -641 -23 1951 Items[2].Count set value 64b
-data modify block -641 -23 1951 Items[3].Count set value 64b
-data modify block -641 -23 1951 Items[4].Count set value 64b
-data modify block -641 -23 1951 Items[5].Count set value 64b
-data modify block -641 -23 1951 Items[6].Count set value 64b
-data modify block -641 -23 1951 Items[7].Count set value 64b
-data modify block -641 -23 1951 Items[8].Count set value 64b
+data modify block -641 -23 1951 Items[].Count set value 64b
 
 ## Example Item: "The Skadoodler"
-data modify block -641 -23 1953 Items[0].Count set value 64b
-data modify block -641 -23 1953 Items[1].Count set value 64b
-data modify block -641 -23 1953 Items[2].Count set value 64b
-data modify block -641 -23 1953 Items[3].Count set value 64b
-data modify block -641 -23 1953 Items[4].Count set value 64b
-data modify block -641 -23 1953 Items[5].Count set value 64b
-data modify block -641 -23 1953 Items[6].Count set value 64b
-data modify block -641 -23 1953 Items[7].Count set value 64b
-data modify block -641 -23 1953 Items[8].Count set value 64b
+data modify block -641 -23 1953 Items[].Count set value 64b
 
 ## Example Item: "The Slab"
-data modify block -641 -23 1954 Items[0].Count set value 64b
-data modify block -641 -23 1954 Items[1].Count set value 64b
-data modify block -641 -23 1954 Items[2].Count set value 64b
-data modify block -641 -23 1954 Items[3].Count set value 64b
-data modify block -641 -23 1954 Items[4].Count set value 64b
-data modify block -641 -23 1954 Items[5].Count set value 64b
-data modify block -641 -23 1954 Items[6].Count set value 64b
-data modify block -641 -23 1954 Items[7].Count set value 64b
-data modify block -641 -23 1954 Items[8].Count set value 64b
+data modify block -641 -23 1954 Items[].Count set value 64b
 
 ## Example Item: "Tome of the Hills"
-data modify block -641 -23 1972 Items[0].Count set value 64b
-data modify block -641 -23 1972 Items[1].Count set value 64b
-data modify block -641 -23 1972 Items[2].Count set value 64b
-data modify block -641 -23 1972 Items[3].Count set value 64b
-data modify block -641 -23 1972 Items[4].Count set value 64b
-data modify block -641 -23 1972 Items[5].Count set value 64b
-data modify block -641 -23 1972 Items[6].Count set value 64b
-data modify block -641 -23 1972 Items[7].Count set value 64b
-data modify block -641 -23 1972 Items[8].Count set value 64b
+data modify block -641 -23 1972 Items[].Count set value 64b
 
 ## Example Item: "Wand of Gorgeousness"
-data modify block -641 -23 1965 Items[0].Count set value 64b
-data modify block -641 -23 1965 Items[1].Count set value 64b
-data modify block -641 -23 1965 Items[2].Count set value 64b
-data modify block -641 -23 1965 Items[3].Count set value 64b
-data modify block -641 -23 1965 Items[4].Count set value 64b
-data modify block -641 -23 1965 Items[5].Count set value 64b
-data modify block -641 -23 1965 Items[6].Count set value 64b
-data modify block -641 -23 1965 Items[7].Count set value 64b
-data modify block -641 -23 1965 Items[8].Count set value 64b
+data modify block -641 -23 1965 Items[].Count set value 64b
 
 # Category "Cards"
 ## Example Item: "Adrenaline Rush"
-data modify block -630 -20 2014 Items[0].Count set value 64b
-data modify block -630 -20 2014 Items[1].Count set value 64b
-data modify block -630 -20 2014 Items[2].Count set value 64b
-data modify block -630 -20 2014 Items[3].Count set value 64b
-data modify block -630 -20 2014 Items[4].Count set value 64b
-data modify block -630 -20 2014 Items[5].Count set value 64b
-data modify block -630 -20 2014 Items[6].Count set value 64b
-data modify block -630 -20 2014 Items[7].Count set value 64b
-data modify block -630 -20 2014 Items[8].Count set value 64b
+data modify block -630 -20 2014 Items[].Count set value 64b
 
 ## Example Item: "Beast Sense"
-data modify block -630 -20 2004 Items[0].Count set value 64b
-data modify block -630 -20 2004 Items[1].Count set value 64b
-data modify block -630 -20 2004 Items[2].Count set value 64b
-data modify block -630 -20 2004 Items[3].Count set value 64b
-data modify block -630 -20 2004 Items[4].Count set value 64b
-data modify block -630 -20 2004 Items[5].Count set value 64b
-data modify block -630 -20 2004 Items[6].Count set value 64b
-data modify block -630 -20 2004 Items[7].Count set value 64b
-data modify block -630 -20 2004 Items[8].Count set value 64b
+data modify block -630 -20 2004 Items[].Count set value 64b
 
 ## Example Item: "Bounding Strides"
-data modify block -630 -20 2005 Items[0].Count set value 64b
-data modify block -630 -20 2005 Items[1].Count set value 64b
-data modify block -630 -20 2005 Items[2].Count set value 64b
-data modify block -630 -20 2005 Items[3].Count set value 64b
-data modify block -630 -20 2005 Items[4].Count set value 64b
-data modify block -630 -20 2005 Items[5].Count set value 64b
-data modify block -630 -20 2005 Items[6].Count set value 64b
-data modify block -630 -20 2005 Items[7].Count set value 64b
-data modify block -630 -20 2005 Items[8].Count set value 64b
+data modify block -630 -20 2005 Items[].Count set value 64b
 
 ## Example Item: "Ember Seeker"
-data modify block -630 -20 1995 Items[0].Count set value 64b
-data modify block -630 -20 1995 Items[1].Count set value 64b
-data modify block -630 -20 1995 Items[2].Count set value 64b
-data modify block -630 -20 1995 Items[3].Count set value 64b
-data modify block -630 -20 1995 Items[4].Count set value 64b
-data modify block -630 -20 1995 Items[5].Count set value 64b
-data modify block -630 -20 1995 Items[6].Count set value 64b
-data modify block -630 -20 1995 Items[7].Count set value 64b
-data modify block -630 -20 1995 Items[8].Count set value 64b
+data modify block -630 -20 1995 Items[].Count set value 64b
 
 ## Example Item: "Evasion"
-data modify block -630 -20 1998 Items[0].Count set value 64b
-data modify block -630 -20 1998 Items[1].Count set value 64b
-data modify block -630 -20 1998 Items[2].Count set value 64b
-data modify block -630 -20 1998 Items[3].Count set value 64b
-data modify block -630 -20 1998 Items[4].Count set value 64b
-data modify block -630 -20 1998 Items[5].Count set value 64b
-data modify block -630 -20 1998 Items[6].Count set value 64b
-data modify block -630 -20 1998 Items[7].Count set value 64b
-data modify block -630 -20 1998 Items[8].Count set value 64b
+data modify block -630 -20 1998 Items[].Count set value 64b
 
 ## Example Item: "Frost Focus"
-data modify block -630 -20 2001 Items[0].Count set value 64b
-data modify block -630 -20 2001 Items[1].Count set value 64b
-data modify block -630 -20 2001 Items[2].Count set value 64b
-data modify block -630 -20 2001 Items[3].Count set value 64b
-data modify block -630 -20 2001 Items[4].Count set value 64b
-data modify block -630 -20 2001 Items[5].Count set value 64b
-data modify block -630 -20 2001 Items[6].Count set value 64b
-data modify block -630 -20 2001 Items[7].Count set value 64b
-data modify block -630 -20 2001 Items[8].Count set value 64b
+data modify block -630 -20 2001 Items[].Count set value 64b
 
 ## Example Item: "Loot and Scoot"
-data modify block -630 -20 2000 Items[0].Count set value 64b
-data modify block -630 -20 2000 Items[1].Count set value 64b
-data modify block -630 -20 2000 Items[2].Count set value 64b
-data modify block -630 -20 2000 Items[3].Count set value 64b
-data modify block -630 -20 2000 Items[4].Count set value 64b
-data modify block -630 -20 2000 Items[5].Count set value 64b
-data modify block -630 -20 2000 Items[6].Count set value 64b
-data modify block -630 -20 2000 Items[7].Count set value 64b
-data modify block -630 -20 2000 Items[8].Count set value 64b
+data modify block -630 -20 2000 Items[].Count set value 64b
 
 ## Example Item: "Moment of Clarity"
-data modify block -630 -20 1996 Items[0].Count set value 64b
-data modify block -630 -20 1996 Items[1].Count set value 64b
-data modify block -630 -20 1996 Items[2].Count set value 64b
-data modify block -630 -20 1996 Items[3].Count set value 64b
-data modify block -630 -20 1996 Items[4].Count set value 64b
-data modify block -630 -20 1996 Items[5].Count set value 64b
-data modify block -630 -20 1996 Items[6].Count set value 64b
-data modify block -630 -20 1996 Items[7].Count set value 64b
-data modify block -630 -20 1996 Items[8].Count set value 64b
+data modify block -630 -20 1996 Items[].Count set value 64b
 
 ## Example Item: "Nimble Looting"
-data modify block -630 -20 2010 Items[0].Count set value 64b
-data modify block -630 -20 2010 Items[1].Count set value 64b
-data modify block -630 -20 2010 Items[2].Count set value 64b
-data modify block -630 -20 2010 Items[3].Count set value 64b
-data modify block -630 -20 2010 Items[4].Count set value 64b
-data modify block -630 -20 2010 Items[5].Count set value 64b
-data modify block -630 -20 2010 Items[6].Count set value 64b
-data modify block -630 -20 2010 Items[7].Count set value 64b
-data modify block -630 -20 2010 Items[8].Count set value 64b
+data modify block -630 -20 2010 Items[].Count set value 64b
 
 ## Example Item: "Quickstep"
-data modify block -630 -20 2012 Items[0].Count set value 64b
-data modify block -630 -20 2012 Items[1].Count set value 64b
-data modify block -630 -20 2012 Items[2].Count set value 64b
-data modify block -630 -20 2012 Items[3].Count set value 64b
-data modify block -630 -20 2012 Items[4].Count set value 64b
-data modify block -630 -20 2012 Items[5].Count set value 64b
-data modify block -630 -20 2012 Items[6].Count set value 64b
-data modify block -630 -20 2012 Items[7].Count set value 64b
-data modify block -630 -20 2012 Items[8].Count set value 64b
+data modify block -630 -20 2012 Items[].Count set value 64b
 
 ## Example Item: "Reckless Charge"
-data modify block -630 -20 2007 Items[0].Count set value 64b
-data modify block -630 -20 2007 Items[1].Count set value 64b
-data modify block -630 -20 2007 Items[2].Count set value 64b
-data modify block -630 -20 2007 Items[3].Count set value 64b
-data modify block -630 -20 2007 Items[4].Count set value 64b
-data modify block -630 -20 2007 Items[5].Count set value 64b
-data modify block -630 -20 2007 Items[6].Count set value 64b
-data modify block -630 -20 2007 Items[7].Count set value 64b
-data modify block -630 -20 2007 Items[8].Count set value 64b
+data modify block -630 -20 2007 Items[].Count set value 64b
 
 ## Example Item: "Second Wind"
-data modify block -630 -20 2003 Items[0].Count set value 64b
-data modify block -630 -20 2003 Items[1].Count set value 64b
-data modify block -630 -20 2003 Items[2].Count set value 64b
-data modify block -630 -20 2003 Items[3].Count set value 64b
-data modify block -630 -20 2003 Items[4].Count set value 64b
-data modify block -630 -20 2003 Items[5].Count set value 64b
-data modify block -630 -20 2003 Items[6].Count set value 64b
-data modify block -630 -20 2003 Items[7].Count set value 64b
-data modify block -630 -20 2003 Items[8].Count set value 64b
+data modify block -630 -20 2003 Items[].Count set value 64b
 
 ## Example Item: "Smash and Grab"
-data modify block -630 -20 2011 Items[0].Count set value 64b
-data modify block -630 -20 2011 Items[1].Count set value 64b
-data modify block -630 -20 2011 Items[2].Count set value 64b
-data modify block -630 -20 2011 Items[3].Count set value 64b
-data modify block -630 -20 2011 Items[4].Count set value 64b
-data modify block -630 -20 2011 Items[5].Count set value 64b
-data modify block -630 -20 2011 Items[6].Count set value 64b
-data modify block -630 -20 2011 Items[7].Count set value 64b
-data modify block -630 -20 2011 Items[8].Count set value 64b
+data modify block -630 -20 2011 Items[].Count set value 64b
 
 ## Example Item: "Sneak"
-data modify block -630 -20 1992 Items[0].Count set value 64b
-data modify block -630 -20 1992 Items[1].Count set value 64b
-data modify block -630 -20 1992 Items[2].Count set value 64b
-data modify block -630 -20 1992 Items[3].Count set value 64b
-data modify block -630 -20 1992 Items[4].Count set value 64b
-data modify block -630 -20 1992 Items[5].Count set value 64b
-data modify block -630 -20 1992 Items[6].Count set value 64b
-data modify block -630 -20 1992 Items[7].Count set value 64b
-data modify block -630 -20 1992 Items[8].Count set value 64b
+data modify block -630 -20 1992 Items[].Count set value 64b
 
 ## Example Item: "Sprint"
-data modify block -630 -20 2008 Items[0].Count set value 64b
-data modify block -630 -20 2008 Items[1].Count set value 64b
-data modify block -630 -20 2008 Items[2].Count set value 64b
-data modify block -630 -20 2008 Items[3].Count set value 64b
-data modify block -630 -20 2008 Items[4].Count set value 64b
-data modify block -630 -20 2008 Items[5].Count set value 64b
-data modify block -630 -20 2008 Items[6].Count set value 64b
-data modify block -630 -20 2008 Items[7].Count set value 64b
-data modify block -630 -20 2008 Items[8].Count set value 64b
+data modify block -630 -20 2008 Items[].Count set value 64b
 
 ## Example Item: "Stability"
-data modify block -630 -20 1993 Items[0].Count set value 64b
-data modify block -630 -20 1993 Items[1].Count set value 64b
-data modify block -630 -20 1993 Items[2].Count set value 64b
-data modify block -630 -20 1993 Items[3].Count set value 64b
-data modify block -630 -20 1993 Items[4].Count set value 64b
-data modify block -630 -20 1993 Items[5].Count set value 64b
-data modify block -630 -20 1993 Items[6].Count set value 64b
-data modify block -630 -20 1993 Items[7].Count set value 64b
-data modify block -630 -20 1993 Items[8].Count set value 64b
+data modify block -630 -20 1993 Items[].Count set value 64b
 
 ## Example Item: "Suit Up"
-data modify block -630 -20 2013 Items[0].Count set value 64b
-data modify block -630 -20 2013 Items[1].Count set value 64b
-data modify block -630 -20 2013 Items[2].Count set value 64b
-data modify block -630 -20 2013 Items[3].Count set value 64b
-data modify block -630 -20 2013 Items[4].Count set value 64b
-data modify block -630 -20 2013 Items[5].Count set value 64b
-data modify block -630 -20 2013 Items[6].Count set value 64b
-data modify block -630 -20 2013 Items[7].Count set value 64b
-data modify block -630 -20 2013 Items[8].Count set value 64b
+data modify block -630 -20 2013 Items[].Count set value 64b
 
 ## Example Item: "Tread Lightly"
-data modify block -630 -20 1999 Items[0].Count set value 64b
-data modify block -630 -20 1999 Items[1].Count set value 64b
-data modify block -630 -20 1999 Items[2].Count set value 64b
-data modify block -630 -20 1999 Items[3].Count set value 64b
-data modify block -630 -20 1999 Items[4].Count set value 64b
-data modify block -630 -20 1999 Items[5].Count set value 64b
-data modify block -630 -20 1999 Items[6].Count set value 64b
-data modify block -630 -20 1999 Items[7].Count set value 64b
-data modify block -630 -20 1999 Items[8].Count set value 64b
+data modify block -630 -20 1999 Items[].Count set value 64b
 
 ## Example Item: "Treasure Hunter"
-data modify block -630 -20 1994 Items[0].Count set value 64b
-data modify block -630 -20 1994 Items[1].Count set value 64b
-data modify block -630 -20 1994 Items[2].Count set value 64b
-data modify block -630 -20 1994 Items[3].Count set value 64b
-data modify block -630 -20 1994 Items[4].Count set value 64b
-data modify block -630 -20 1994 Items[5].Count set value 64b
-data modify block -630 -20 1994 Items[6].Count set value 64b
-data modify block -630 -20 1994 Items[7].Count set value 64b
-data modify block -630 -20 1994 Items[8].Count set value 64b
+data modify block -630 -20 1994 Items[].Count set value 64b
 
 # Category "Compass"
 ## Example Item: "Compass Level Token"
-data modify block -557 109 1982 Items[0].Count set value 64b
-data modify block -557 109 1982 Items[1].Count set value 64b
-data modify block -557 109 1982 Items[2].Count set value 64b
-data modify block -557 109 1982 Items[3].Count set value 64b
-data modify block -557 109 1982 Items[4].Count set value 64b
-data modify block -557 109 1982 Items[5].Count set value 64b
-data modify block -557 109 1982 Items[6].Count set value 64b
-data modify block -557 109 1982 Items[7].Count set value 64b
-data modify block -557 109 1982 Items[8].Count set value 64b
+data modify block -557 109 1982 Items[].Count set value 64b
 
 ## Example Item: "Compass Level Token"
-data modify block -558 109 1982 Items[0].Count set value 64b
-data modify block -558 109 1982 Items[1].Count set value 64b
-data modify block -558 109 1982 Items[2].Count set value 64b
-data modify block -558 109 1982 Items[3].Count set value 64b
-data modify block -558 109 1982 Items[4].Count set value 64b
-data modify block -558 109 1982 Items[5].Count set value 64b
-data modify block -558 109 1982 Items[6].Count set value 64b
-data modify block -558 109 1982 Items[7].Count set value 64b
-data modify block -558 109 1982 Items[8].Count set value 64b
+data modify block -558 109 1982 Items[].Count set value 64b
 
 ## Example Item: "Compass Level Token"
-data modify block -559 109 1982 Items[0].Count set value 64b
-data modify block -559 109 1982 Items[1].Count set value 64b
-data modify block -559 109 1982 Items[2].Count set value 64b
-data modify block -559 109 1982 Items[3].Count set value 64b
-data modify block -559 109 1982 Items[4].Count set value 64b
-data modify block -559 109 1982 Items[5].Count set value 64b
-data modify block -559 109 1982 Items[6].Count set value 64b
-data modify block -559 109 1982 Items[7].Count set value 64b
-data modify block -559 109 1982 Items[8].Count set value 64b
+data modify block -559 109 1982 Items[].Count set value 64b
 
 ## Example Item: "Compass Level Token"
-data modify block -560 109 1982 Items[0].Count set value 64b
-data modify block -560 109 1982 Items[1].Count set value 64b
-data modify block -560 109 1982 Items[2].Count set value 64b
-data modify block -560 109 1982 Items[3].Count set value 64b
-data modify block -560 109 1982 Items[4].Count set value 64b
-data modify block -560 109 1982 Items[5].Count set value 64b
-data modify block -560 109 1982 Items[6].Count set value 64b
-data modify block -560 109 1982 Items[7].Count set value 64b
-data modify block -560 109 1982 Items[8].Count set value 64b
+data modify block -560 109 1982 Items[].Count set value 64b
 
 ## Example Item: "Compass Level Token"
-data modify block -561 109 1982 Items[0].Count set value 64b
-data modify block -561 109 1982 Items[1].Count set value 64b
-data modify block -561 109 1982 Items[2].Count set value 64b
-data modify block -561 109 1982 Items[3].Count set value 64b
-data modify block -561 109 1982 Items[4].Count set value 64b
-data modify block -561 109 1982 Items[5].Count set value 64b
-data modify block -561 109 1982 Items[6].Count set value 64b
-data modify block -561 109 1982 Items[7].Count set value 64b
-data modify block -561 109 1982 Items[8].Count set value 64b
+data modify block -561 109 1982 Items[].Count set value 64b
 
 ## Example Item: "Manual Compass"
-data modify block -549 106 1970 Items[0].Count set value 64b
-data modify block -549 106 1970 Items[1].Count set value 64b
-data modify block -549 106 1970 Items[2].Count set value 64b
-data modify block -549 106 1970 Items[3].Count set value 64b
-data modify block -549 106 1970 Items[4].Count set value 64b
-data modify block -549 106 1970 Items[5].Count set value 64b
-data modify block -549 106 1970 Items[6].Count set value 64b
-data modify block -549 106 1970 Items[7].Count set value 64b
-data modify block -549 106 1970 Items[8].Count set value 64b
+data modify block -549 106 1970 Items[].Count set value 64b
 
 ## Example Item: "Manual Compass"
-data modify block -549 106 1971 Items[0].Count set value 64b
-data modify block -549 106 1971 Items[1].Count set value 64b
-data modify block -549 106 1971 Items[2].Count set value 64b
-data modify block -549 106 1971 Items[3].Count set value 64b
-data modify block -549 106 1971 Items[4].Count set value 64b
-data modify block -549 106 1971 Items[5].Count set value 64b
-data modify block -549 106 1971 Items[6].Count set value 64b
-data modify block -549 106 1971 Items[7].Count set value 64b
-data modify block -549 106 1971 Items[8].Count set value 64b
+data modify block -549 106 1971 Items[].Count set value 64b
 
 ## Example Item: "Manual Compass"
-data modify block -549 106 1972 Items[0].Count set value 64b
-data modify block -549 106 1972 Items[1].Count set value 64b
-data modify block -549 106 1972 Items[2].Count set value 64b
-data modify block -549 106 1972 Items[3].Count set value 64b
-data modify block -549 106 1972 Items[4].Count set value 64b
-data modify block -549 106 1972 Items[5].Count set value 64b
-data modify block -549 106 1972 Items[6].Count set value 64b
-data modify block -549 106 1972 Items[7].Count set value 64b
-data modify block -549 106 1972 Items[8].Count set value 64b
+data modify block -549 106 1972 Items[].Count set value 64b
 
 ## Example Item: "Manual Compass"
-data modify block -549 106 1973 Items[0].Count set value 64b
-data modify block -549 106 1973 Items[1].Count set value 64b
-data modify block -549 106 1973 Items[2].Count set value 64b
-data modify block -549 106 1973 Items[3].Count set value 64b
-data modify block -549 106 1973 Items[4].Count set value 64b
-data modify block -549 106 1973 Items[5].Count set value 64b
-data modify block -549 106 1973 Items[6].Count set value 64b
-data modify block -549 106 1973 Items[7].Count set value 64b
-data modify block -549 106 1973 Items[8].Count set value 64b
+data modify block -549 106 1973 Items[].Count set value 64b
 
 ## Example Item: "Manual Compass"
-data modify block -549 106 1974 Items[0].Count set value 64b
-data modify block -549 106 1974 Items[1].Count set value 64b
-data modify block -549 106 1974 Items[2].Count set value 64b
-data modify block -549 106 1974 Items[3].Count set value 64b
-data modify block -549 106 1974 Items[4].Count set value 64b
-data modify block -549 106 1974 Items[5].Count set value 64b
-data modify block -549 106 1974 Items[6].Count set value 64b
-data modify block -549 106 1974 Items[7].Count set value 64b
-data modify block -549 106 1974 Items[8].Count set value 64b
+data modify block -549 106 1974 Items[].Count set value 64b
 
 ## Example Item: "Manual Compass"
-data modify block -549 106 1975 Items[0].Count set value 64b
-data modify block -549 106 1975 Items[1].Count set value 64b
-data modify block -549 106 1975 Items[2].Count set value 64b
-data modify block -549 106 1975 Items[3].Count set value 64b
-data modify block -549 106 1975 Items[4].Count set value 64b
-data modify block -549 106 1975 Items[5].Count set value 64b
-data modify block -549 106 1975 Items[6].Count set value 64b
-data modify block -549 106 1975 Items[7].Count set value 64b
-data modify block -549 106 1975 Items[8].Count set value 64b
+data modify block -549 106 1975 Items[].Count set value 64b
 
 ## Example Item: "Manual Compass"
-data modify block -549 106 1976 Items[0].Count set value 64b
-data modify block -549 106 1976 Items[1].Count set value 64b
-data modify block -549 106 1976 Items[2].Count set value 64b
-data modify block -549 106 1976 Items[3].Count set value 64b
-data modify block -549 106 1976 Items[4].Count set value 64b
-data modify block -549 106 1976 Items[5].Count set value 64b
-data modify block -549 106 1976 Items[6].Count set value 64b
-data modify block -549 106 1976 Items[7].Count set value 64b
-data modify block -549 106 1976 Items[8].Count set value 64b
+data modify block -549 106 1976 Items[].Count set value 64b
 
 ## Example Item: "Manual Compass"
-data modify block -549 106 1977 Items[0].Count set value 64b
-data modify block -549 106 1977 Items[1].Count set value 64b
-data modify block -549 106 1977 Items[2].Count set value 64b
-data modify block -549 106 1977 Items[3].Count set value 64b
-data modify block -549 106 1977 Items[4].Count set value 64b
-data modify block -549 106 1977 Items[5].Count set value 64b
-data modify block -549 106 1977 Items[6].Count set value 64b
-data modify block -549 106 1977 Items[7].Count set value 64b
-data modify block -549 106 1977 Items[8].Count set value 64b
+data modify block -549 106 1977 Items[].Count set value 64b
 
 ## Example Item: "Manual Compass"
-data modify block -549 106 1978 Items[0].Count set value 64b
-data modify block -549 106 1978 Items[1].Count set value 64b
-data modify block -549 106 1978 Items[2].Count set value 64b
-data modify block -549 106 1978 Items[3].Count set value 64b
-data modify block -549 106 1978 Items[4].Count set value 64b
-data modify block -549 106 1978 Items[5].Count set value 64b
-data modify block -549 106 1978 Items[6].Count set value 64b
-data modify block -549 106 1978 Items[7].Count set value 64b
-data modify block -549 106 1978 Items[8].Count set value 64b
+data modify block -549 106 1978 Items[].Count set value 64b
 
 ## Example Item: "Manual Compass"
-data modify block -549 106 1979 Items[0].Count set value 64b
-data modify block -549 106 1979 Items[1].Count set value 64b
-data modify block -549 106 1979 Items[2].Count set value 64b
-data modify block -549 106 1979 Items[3].Count set value 64b
-data modify block -549 106 1979 Items[4].Count set value 64b
-data modify block -549 106 1979 Items[5].Count set value 64b
-data modify block -549 106 1979 Items[6].Count set value 64b
-data modify block -549 106 1979 Items[7].Count set value 64b
-data modify block -549 106 1979 Items[8].Count set value 64b
+data modify block -549 106 1979 Items[].Count set value 64b
 
 # Category "Ember"
 ## Example Item: "Decked Out Frost Ember"
-data modify block -478 19 2009 Items[0].Count set value 64b
-data modify block -478 19 2009 Items[1].Count set value 64b
-data modify block -478 19 2009 Items[2].Count set value 64b
-data modify block -478 19 2009 Items[3].Count set value 64b
-data modify block -478 19 2009 Items[4].Count set value 64b
-data modify block -478 19 2009 Items[5].Count set value 64b
-data modify block -478 19 2009 Items[6].Count set value 64b
-data modify block -478 19 2009 Items[7].Count set value 64b
-data modify block -478 19 2009 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -484 53 1988 Items[0].Count set value 64b
-data modify block -484 53 1988 Items[1].Count set value 64b
-data modify block -484 53 1988 Items[2].Count set value 64b
-data modify block -484 53 1988 Items[3].Count set value 64b
-data modify block -484 53 1988 Items[4].Count set value 64b
-data modify block -484 53 1988 Items[5].Count set value 64b
-data modify block -484 53 1988 Items[6].Count set value 64b
-data modify block -484 53 1988 Items[7].Count set value 64b
-data modify block -484 53 1988 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -485 31 1962 Items[0].Count set value 64b
-data modify block -485 31 1962 Items[1].Count set value 64b
-data modify block -485 31 1962 Items[2].Count set value 64b
-data modify block -485 31 1962 Items[3].Count set value 64b
-data modify block -485 31 1962 Items[4].Count set value 64b
-data modify block -485 31 1962 Items[5].Count set value 64b
-data modify block -485 31 1962 Items[6].Count set value 64b
-data modify block -485 31 1962 Items[7].Count set value 64b
-data modify block -485 31 1962 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -489 11 2007 Items[0].Count set value 64b
-data modify block -489 11 2007 Items[1].Count set value 64b
-data modify block -489 11 2007 Items[2].Count set value 64b
-data modify block -489 11 2007 Items[3].Count set value 64b
-data modify block -489 11 2007 Items[4].Count set value 64b
-data modify block -489 11 2007 Items[5].Count set value 64b
-data modify block -489 11 2007 Items[6].Count set value 64b
-data modify block -489 11 2007 Items[7].Count set value 64b
-data modify block -489 11 2007 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -490 50 2016 Items[0].Count set value 64b
-data modify block -490 50 2016 Items[1].Count set value 64b
-data modify block -490 50 2016 Items[2].Count set value 64b
-data modify block -490 50 2016 Items[3].Count set value 64b
-data modify block -490 50 2016 Items[4].Count set value 64b
-data modify block -490 50 2016 Items[5].Count set value 64b
-data modify block -490 50 2016 Items[6].Count set value 64b
-data modify block -490 50 2016 Items[7].Count set value 64b
-data modify block -490 50 2016 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -496 15 1999 Items[0].Count set value 64b
-data modify block -496 15 1999 Items[1].Count set value 64b
-data modify block -496 15 1999 Items[2].Count set value 64b
-data modify block -496 15 1999 Items[3].Count set value 64b
-data modify block -496 15 1999 Items[4].Count set value 64b
-data modify block -496 15 1999 Items[5].Count set value 64b
-data modify block -496 15 1999 Items[6].Count set value 64b
-data modify block -496 15 1999 Items[7].Count set value 64b
-data modify block -496 15 1999 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -498 51 1980 Items[0].Count set value 64b
-data modify block -498 51 1980 Items[1].Count set value 64b
-data modify block -498 51 1980 Items[2].Count set value 64b
-data modify block -498 51 1980 Items[3].Count set value 64b
-data modify block -498 51 1980 Items[4].Count set value 64b
-data modify block -498 51 1980 Items[5].Count set value 64b
-data modify block -498 51 1980 Items[6].Count set value 64b
-data modify block -498 51 1980 Items[7].Count set value 64b
-data modify block -498 51 1980 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -501 16 1972 Items[0].Count set value 64b
-data modify block -501 16 1972 Items[1].Count set value 64b
-data modify block -501 16 1972 Items[2].Count set value 64b
-data modify block -501 16 1972 Items[3].Count set value 64b
-data modify block -501 16 1972 Items[4].Count set value 64b
-data modify block -501 16 1972 Items[5].Count set value 64b
-data modify block -501 16 1972 Items[6].Count set value 64b
-data modify block -501 16 1972 Items[7].Count set value 64b
-data modify block -501 16 1972 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -502 31 1975 Items[0].Count set value 64b
-data modify block -502 31 1975 Items[1].Count set value 64b
-data modify block -502 31 1975 Items[2].Count set value 64b
-data modify block -502 31 1975 Items[3].Count set value 64b
-data modify block -502 31 1975 Items[4].Count set value 64b
-data modify block -502 31 1975 Items[5].Count set value 64b
-data modify block -502 31 1975 Items[6].Count set value 64b
-data modify block -502 31 1975 Items[7].Count set value 64b
-data modify block -502 31 1975 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -508 9 1951 Items[0].Count set value 64b
-data modify block -508 9 1951 Items[1].Count set value 64b
-data modify block -508 9 1951 Items[2].Count set value 64b
-data modify block -508 9 1951 Items[3].Count set value 64b
-data modify block -508 9 1951 Items[4].Count set value 64b
-data modify block -508 9 1951 Items[5].Count set value 64b
-data modify block -508 9 1951 Items[6].Count set value 64b
-data modify block -508 9 1951 Items[7].Count set value 64b
-data modify block -508 9 1951 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -509 14 2033 Items[0].Count set value 64b
-data modify block -509 14 2033 Items[1].Count set value 64b
-data modify block -509 14 2033 Items[2].Count set value 64b
-data modify block -509 14 2033 Items[3].Count set value 64b
-data modify block -509 14 2033 Items[4].Count set value 64b
-data modify block -509 14 2033 Items[5].Count set value 64b
-data modify block -509 14 2033 Items[6].Count set value 64b
-data modify block -509 14 2033 Items[7].Count set value 64b
-data modify block -509 14 2033 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -513 51 1962 Items[0].Count set value 64b
-data modify block -513 51 1962 Items[1].Count set value 64b
-data modify block -513 51 1962 Items[2].Count set value 64b
-data modify block -513 51 1962 Items[3].Count set value 64b
-data modify block -513 51 1962 Items[4].Count set value 64b
-data modify block -513 51 1962 Items[5].Count set value 64b
-data modify block -513 51 1962 Items[6].Count set value 64b
-data modify block -513 51 1962 Items[7].Count set value 64b
-data modify block -513 51 1962 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -515 46 2031 Items[0].Count set value 64b
-data modify block -515 46 2031 Items[1].Count set value 64b
-data modify block -515 46 2031 Items[2].Count set value 64b
-data modify block -515 46 2031 Items[3].Count set value 64b
-data modify block -515 46 2031 Items[4].Count set value 64b
-data modify block -515 46 2031 Items[5].Count set value 64b
-data modify block -515 46 2031 Items[6].Count set value 64b
-data modify block -515 46 2031 Items[7].Count set value 64b
-data modify block -515 46 2031 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -518 2 2007 Items[0].Count set value 64b
-data modify block -518 2 2007 Items[1].Count set value 64b
-data modify block -518 2 2007 Items[2].Count set value 64b
-data modify block -518 2 2007 Items[3].Count set value 64b
-data modify block -518 2 2007 Items[4].Count set value 64b
-data modify block -518 2 2007 Items[5].Count set value 64b
-data modify block -518 2 2007 Items[6].Count set value 64b
-data modify block -518 2 2007 Items[7].Count set value 64b
-data modify block -518 2 2007 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -518 53 2011 Items[0].Count set value 64b
-data modify block -518 53 2011 Items[1].Count set value 64b
-data modify block -518 53 2011 Items[2].Count set value 64b
-data modify block -518 53 2011 Items[3].Count set value 64b
-data modify block -518 53 2011 Items[4].Count set value 64b
-data modify block -518 53 2011 Items[5].Count set value 64b
-data modify block -518 53 2011 Items[6].Count set value 64b
-data modify block -518 53 2011 Items[7].Count set value 64b
-data modify block -518 53 2011 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -518 53 2011 Items[0].Count set value 64b
-data modify block -518 53 2011 Items[1].Count set value 64b
-data modify block -518 53 2011 Items[2].Count set value 64b
-data modify block -518 53 2011 Items[3].Count set value 64b
-data modify block -518 53 2011 Items[4].Count set value 64b
-data modify block -518 53 2011 Items[5].Count set value 64b
-data modify block -518 53 2011 Items[6].Count set value 64b
-data modify block -518 53 2011 Items[7].Count set value 64b
-data modify block -518 53 2011 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -519 35 2002 Items[0].Count set value 64b
-data modify block -519 35 2002 Items[1].Count set value 64b
-data modify block -519 35 2002 Items[2].Count set value 64b
-data modify block -519 35 2002 Items[3].Count set value 64b
-data modify block -519 35 2002 Items[4].Count set value 64b
-data modify block -519 35 2002 Items[5].Count set value 64b
-data modify block -519 35 2002 Items[6].Count set value 64b
-data modify block -519 35 2002 Items[7].Count set value 64b
-data modify block -519 35 2002 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -521 35 1981 Items[0].Count set value 64b
-data modify block -521 35 1981 Items[1].Count set value 64b
-data modify block -521 35 1981 Items[2].Count set value 64b
-data modify block -521 35 1981 Items[3].Count set value 64b
-data modify block -521 35 1981 Items[4].Count set value 64b
-data modify block -521 35 1981 Items[5].Count set value 64b
-data modify block -521 35 1981 Items[6].Count set value 64b
-data modify block -521 35 1981 Items[7].Count set value 64b
-data modify block -521 35 1981 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -526 12 1941 Items[0].Count set value 64b
-data modify block -526 12 1941 Items[1].Count set value 64b
-data modify block -526 12 1941 Items[2].Count set value 64b
-data modify block -526 12 1941 Items[3].Count set value 64b
-data modify block -526 12 1941 Items[4].Count set value 64b
-data modify block -526 12 1941 Items[5].Count set value 64b
-data modify block -526 12 1941 Items[6].Count set value 64b
-data modify block -526 12 1941 Items[7].Count set value 64b
-data modify block -526 12 1941 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -527 51 1974 Items[0].Count set value 64b
-data modify block -527 51 1974 Items[1].Count set value 64b
-data modify block -527 51 1974 Items[2].Count set value 64b
-data modify block -527 51 1974 Items[3].Count set value 64b
-data modify block -527 51 1974 Items[4].Count set value 64b
-data modify block -527 51 1974 Items[5].Count set value 64b
-data modify block -527 51 1974 Items[6].Count set value 64b
-data modify block -527 51 1974 Items[7].Count set value 64b
-data modify block -527 51 1974 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -528 12 2032 Items[0].Count set value 64b
-data modify block -528 12 2032 Items[1].Count set value 64b
-data modify block -528 12 2032 Items[2].Count set value 64b
-data modify block -528 12 2032 Items[3].Count set value 64b
-data modify block -528 12 2032 Items[4].Count set value 64b
-data modify block -528 12 2032 Items[5].Count set value 64b
-data modify block -528 12 2032 Items[6].Count set value 64b
-data modify block -528 12 2032 Items[7].Count set value 64b
-data modify block -528 12 2032 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -531 16 1989 Items[0].Count set value 64b
-data modify block -531 16 1989 Items[1].Count set value 64b
-data modify block -531 16 1989 Items[2].Count set value 64b
-data modify block -531 16 1989 Items[3].Count set value 64b
-data modify block -531 16 1989 Items[4].Count set value 64b
-data modify block -531 16 1989 Items[5].Count set value 64b
-data modify block -531 16 1989 Items[6].Count set value 64b
-data modify block -531 16 1989 Items[7].Count set value 64b
-data modify block -531 16 1989 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -533 44 2024 Items[0].Count set value 64b
-data modify block -533 44 2024 Items[1].Count set value 64b
-data modify block -533 44 2024 Items[2].Count set value 64b
-data modify block -533 44 2024 Items[3].Count set value 64b
-data modify block -533 44 2024 Items[4].Count set value 64b
-data modify block -533 44 2024 Items[5].Count set value 64b
-data modify block -533 44 2024 Items[6].Count set value 64b
-data modify block -533 44 2024 Items[7].Count set value 64b
-data modify block -533 44 2024 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -537 45 1948 Items[0].Count set value 64b
-data modify block -537 45 1948 Items[1].Count set value 64b
-data modify block -537 45 1948 Items[2].Count set value 64b
-data modify block -537 45 1948 Items[3].Count set value 64b
-data modify block -537 45 1948 Items[4].Count set value 64b
-data modify block -537 45 1948 Items[5].Count set value 64b
-data modify block -537 45 1948 Items[6].Count set value 64b
-data modify block -537 45 1948 Items[7].Count set value 64b
-data modify block -537 45 1948 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -542 11 1998 Items[0].Count set value 64b
-data modify block -542 11 1998 Items[1].Count set value 64b
-data modify block -542 11 1998 Items[2].Count set value 64b
-data modify block -542 11 1998 Items[3].Count set value 64b
-data modify block -542 11 1998 Items[4].Count set value 64b
-data modify block -542 11 1998 Items[5].Count set value 64b
-data modify block -542 11 1998 Items[6].Count set value 64b
-data modify block -542 11 1998 Items[7].Count set value 64b
-data modify block -542 11 1998 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -545 51 2008 Items[0].Count set value 64b
-data modify block -545 51 2008 Items[1].Count set value 64b
-data modify block -545 51 2008 Items[2].Count set value 64b
-data modify block -545 51 2008 Items[3].Count set value 64b
-data modify block -545 51 2008 Items[4].Count set value 64b
-data modify block -545 51 2008 Items[5].Count set value 64b
-data modify block -545 51 2008 Items[6].Count set value 64b
-data modify block -545 51 2008 Items[7].Count set value 64b
-data modify block -545 51 2008 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -548 11 1976 Items[0].Count set value 64b
-data modify block -548 11 1976 Items[1].Count set value 64b
-data modify block -548 11 1976 Items[2].Count set value 64b
-data modify block -548 11 1976 Items[3].Count set value 64b
-data modify block -548 11 1976 Items[4].Count set value 64b
-data modify block -548 11 1976 Items[5].Count set value 64b
-data modify block -548 11 1976 Items[6].Count set value 64b
-data modify block -548 11 1976 Items[7].Count set value 64b
-data modify block -548 11 1976 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -553 10 2037 Items[0].Count set value 64b
-data modify block -553 10 2037 Items[1].Count set value 64b
-data modify block -553 10 2037 Items[2].Count set value 64b
-data modify block -553 10 2037 Items[3].Count set value 64b
-data modify block -553 10 2037 Items[4].Count set value 64b
-data modify block -553 10 2037 Items[5].Count set value 64b
-data modify block -553 10 2037 Items[6].Count set value 64b
-data modify block -553 10 2037 Items[7].Count set value 64b
-data modify block -553 10 2037 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -554 51 2008 Items[0].Count set value 64b
-data modify block -554 51 2008 Items[1].Count set value 64b
-data modify block -554 51 2008 Items[2].Count set value 64b
-data modify block -554 51 2008 Items[3].Count set value 64b
-data modify block -554 51 2008 Items[4].Count set value 64b
-data modify block -554 51 2008 Items[5].Count set value 64b
-data modify block -554 51 2008 Items[6].Count set value 64b
-data modify block -554 51 2008 Items[7].Count set value 64b
-data modify block -554 51 2008 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -558 45 1976 Items[0].Count set value 64b
-data modify block -558 45 1976 Items[1].Count set value 64b
-data modify block -558 45 1976 Items[2].Count set value 64b
-data modify block -558 45 1976 Items[3].Count set value 64b
-data modify block -558 45 1976 Items[4].Count set value 64b
-data modify block -558 45 1976 Items[5].Count set value 64b
-data modify block -558 45 1976 Items[6].Count set value 64b
-data modify block -558 45 1976 Items[7].Count set value 64b
-data modify block -558 45 1976 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -558 46 2022 Items[0].Count set value 64b
-data modify block -558 46 2022 Items[1].Count set value 64b
-data modify block -558 46 2022 Items[2].Count set value 64b
-data modify block -558 46 2022 Items[3].Count set value 64b
-data modify block -558 46 2022 Items[4].Count set value 64b
-data modify block -558 46 2022 Items[5].Count set value 64b
-data modify block -558 46 2022 Items[6].Count set value 64b
-data modify block -558 46 2022 Items[7].Count set value 64b
-data modify block -558 46 2022 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -560 47 1942 Items[0].Count set value 64b
-data modify block -560 47 1942 Items[1].Count set value 64b
-data modify block -560 47 1942 Items[2].Count set value 64b
-data modify block -560 47 1942 Items[3].Count set value 64b
-data modify block -560 47 1942 Items[4].Count set value 64b
-data modify block -560 47 1942 Items[5].Count set value 64b
-data modify block -560 47 1942 Items[6].Count set value 64b
-data modify block -560 47 1942 Items[7].Count set value 64b
-data modify block -560 47 1942 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -565 36 1999 Items[0].Count set value 64b
-data modify block -565 36 1999 Items[1].Count set value 64b
-data modify block -565 36 1999 Items[2].Count set value 64b
-data modify block -565 36 1999 Items[3].Count set value 64b
-data modify block -565 36 1999 Items[4].Count set value 64b
-data modify block -565 36 1999 Items[5].Count set value 64b
-data modify block -565 36 1999 Items[6].Count set value 64b
-data modify block -565 36 1999 Items[7].Count set value 64b
-data modify block -565 36 1999 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -569 8 1964 Items[0].Count set value 64b
-data modify block -569 8 1964 Items[1].Count set value 64b
-data modify block -569 8 1964 Items[2].Count set value 64b
-data modify block -569 8 1964 Items[3].Count set value 64b
-data modify block -569 8 1964 Items[4].Count set value 64b
-data modify block -569 8 1964 Items[5].Count set value 64b
-data modify block -569 8 1964 Items[6].Count set value 64b
-data modify block -569 8 1964 Items[7].Count set value 64b
-data modify block -569 8 1964 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -573 11 2007 Items[0].Count set value 64b
-data modify block -573 11 2007 Items[1].Count set value 64b
-data modify block -573 11 2007 Items[2].Count set value 64b
-data modify block -573 11 2007 Items[3].Count set value 64b
-data modify block -573 11 2007 Items[4].Count set value 64b
-data modify block -573 11 2007 Items[5].Count set value 64b
-data modify block -573 11 2007 Items[6].Count set value 64b
-data modify block -573 11 2007 Items[7].Count set value 64b
-data modify block -573 11 2007 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -573 36 1998 Items[0].Count set value 64b
-data modify block -573 36 1998 Items[1].Count set value 64b
-data modify block -573 36 1998 Items[2].Count set value 64b
-data modify block -573 36 1998 Items[3].Count set value 64b
-data modify block -573 36 1998 Items[4].Count set value 64b
-data modify block -573 36 1998 Items[5].Count set value 64b
-data modify block -573 36 1998 Items[6].Count set value 64b
-data modify block -573 36 1998 Items[7].Count set value 64b
-data modify block -573 36 1998 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -579 -37 1835 Items[0].Count set value 64b
-data modify block -579 -37 1835 Items[1].Count set value 64b
-data modify block -579 -37 1835 Items[2].Count set value 64b
-data modify block -579 -37 1835 Items[3].Count set value 64b
-data modify block -579 -37 1835 Items[4].Count set value 64b
-data modify block -579 -37 1835 Items[5].Count set value 64b
-data modify block -579 -37 1835 Items[6].Count set value 64b
-data modify block -579 -37 1835 Items[7].Count set value 64b
-data modify block -579 -37 1835 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -582 13 1934 Items[0].Count set value 64b
-data modify block -582 13 1934 Items[1].Count set value 64b
-data modify block -582 13 1934 Items[2].Count set value 64b
-data modify block -582 13 1934 Items[3].Count set value 64b
-data modify block -582 13 1934 Items[4].Count set value 64b
-data modify block -582 13 1934 Items[5].Count set value 64b
-data modify block -582 13 1934 Items[6].Count set value 64b
-data modify block -582 13 1934 Items[7].Count set value 64b
-data modify block -582 13 1934 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -582 13 1935 Items[0].Count set value 64b
-data modify block -582 13 1935 Items[1].Count set value 64b
-data modify block -582 13 1935 Items[2].Count set value 64b
-data modify block -582 13 1935 Items[3].Count set value 64b
-data modify block -582 13 1935 Items[4].Count set value 64b
-data modify block -582 13 1935 Items[5].Count set value 64b
-data modify block -582 13 1935 Items[6].Count set value 64b
-data modify block -582 13 1935 Items[7].Count set value 64b
-data modify block -582 13 1935 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -582 13 1936 Items[0].Count set value 64b
-data modify block -582 13 1936 Items[1].Count set value 64b
-data modify block -582 13 1936 Items[2].Count set value 64b
-data modify block -582 13 1936 Items[3].Count set value 64b
-data modify block -582 13 1936 Items[4].Count set value 64b
-data modify block -582 13 1936 Items[5].Count set value 64b
-data modify block -582 13 1936 Items[6].Count set value 64b
-data modify block -582 13 1936 Items[7].Count set value 64b
-data modify block -582 13 1936 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -582 13 1937 Items[0].Count set value 64b
-data modify block -582 13 1937 Items[1].Count set value 64b
-data modify block -582 13 1937 Items[2].Count set value 64b
-data modify block -582 13 1937 Items[3].Count set value 64b
-data modify block -582 13 1937 Items[4].Count set value 64b
-data modify block -582 13 1937 Items[5].Count set value 64b
-data modify block -582 13 1937 Items[6].Count set value 64b
-data modify block -582 13 1937 Items[7].Count set value 64b
-data modify block -582 13 1937 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -582 9 1955 Items[0].Count set value 64b
-data modify block -582 9 1955 Items[1].Count set value 64b
-data modify block -582 9 1955 Items[2].Count set value 64b
-data modify block -582 9 1955 Items[3].Count set value 64b
-data modify block -582 9 1955 Items[4].Count set value 64b
-data modify block -582 9 1955 Items[5].Count set value 64b
-data modify block -582 9 1955 Items[6].Count set value 64b
-data modify block -582 9 1955 Items[7].Count set value 64b
-data modify block -582 9 1955 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -583 45 2013 Items[0].Count set value 64b
-data modify block -583 45 2013 Items[1].Count set value 64b
-data modify block -583 45 2013 Items[2].Count set value 64b
-data modify block -583 45 2013 Items[3].Count set value 64b
-data modify block -583 45 2013 Items[4].Count set value 64b
-data modify block -583 45 2013 Items[5].Count set value 64b
-data modify block -583 45 2013 Items[6].Count set value 64b
-data modify block -583 45 2013 Items[7].Count set value 64b
-data modify block -583 45 2013 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -584 -17 1927 Items[0].Count set value 64b
-data modify block -584 -17 1927 Items[1].Count set value 64b
-data modify block -584 -17 1927 Items[2].Count set value 64b
-data modify block -584 -17 1927 Items[3].Count set value 64b
-data modify block -584 -17 1927 Items[4].Count set value 64b
-data modify block -584 -17 1927 Items[5].Count set value 64b
-data modify block -584 -17 1927 Items[6].Count set value 64b
-data modify block -584 -17 1927 Items[7].Count set value 64b
-data modify block -584 -17 1927 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -584 13 1934 Items[0].Count set value 64b
-data modify block -584 13 1934 Items[1].Count set value 64b
-data modify block -584 13 1934 Items[2].Count set value 64b
-data modify block -584 13 1934 Items[3].Count set value 64b
-data modify block -584 13 1934 Items[4].Count set value 64b
-data modify block -584 13 1934 Items[5].Count set value 64b
-data modify block -584 13 1934 Items[6].Count set value 64b
-data modify block -584 13 1934 Items[7].Count set value 64b
-data modify block -584 13 1934 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -584 13 1935 Items[0].Count set value 64b
-data modify block -584 13 1935 Items[1].Count set value 64b
-data modify block -584 13 1935 Items[2].Count set value 64b
-data modify block -584 13 1935 Items[3].Count set value 64b
-data modify block -584 13 1935 Items[4].Count set value 64b
-data modify block -584 13 1935 Items[5].Count set value 64b
-data modify block -584 13 1935 Items[6].Count set value 64b
-data modify block -584 13 1935 Items[7].Count set value 64b
-data modify block -584 13 1935 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -584 13 1936 Items[0].Count set value 64b
-data modify block -584 13 1936 Items[1].Count set value 64b
-data modify block -584 13 1936 Items[2].Count set value 64b
-data modify block -584 13 1936 Items[3].Count set value 64b
-data modify block -584 13 1936 Items[4].Count set value 64b
-data modify block -584 13 1936 Items[5].Count set value 64b
-data modify block -584 13 1936 Items[6].Count set value 64b
-data modify block -584 13 1936 Items[7].Count set value 64b
-data modify block -584 13 1936 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -584 13 1937 Items[0].Count set value 64b
-data modify block -584 13 1937 Items[1].Count set value 64b
-data modify block -584 13 1937 Items[2].Count set value 64b
-data modify block -584 13 1937 Items[3].Count set value 64b
-data modify block -584 13 1937 Items[4].Count set value 64b
-data modify block -584 13 1937 Items[5].Count set value 64b
-data modify block -584 13 1937 Items[6].Count set value 64b
-data modify block -584 13 1937 Items[7].Count set value 64b
-data modify block -584 13 1937 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -585 -9 1920 Items[0].Count set value 64b
-data modify block -585 -9 1920 Items[1].Count set value 64b
-data modify block -585 -9 1920 Items[2].Count set value 64b
-data modify block -585 -9 1920 Items[3].Count set value 64b
-data modify block -585 -9 1920 Items[4].Count set value 64b
-data modify block -585 -9 1920 Items[5].Count set value 64b
-data modify block -585 -9 1920 Items[6].Count set value 64b
-data modify block -585 -9 1920 Items[7].Count set value 64b
-data modify block -585 -9 1920 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -586 1 1888 Items[0].Count set value 64b
-data modify block -586 1 1888 Items[1].Count set value 64b
-data modify block -586 1 1888 Items[2].Count set value 64b
-data modify block -586 1 1888 Items[3].Count set value 64b
-data modify block -586 1 1888 Items[4].Count set value 64b
-data modify block -586 1 1888 Items[5].Count set value 64b
-data modify block -586 1 1888 Items[6].Count set value 64b
-data modify block -586 1 1888 Items[7].Count set value 64b
-data modify block -586 1 1888 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -587 52 1951 Items[0].Count set value 64b
-data modify block -587 52 1951 Items[1].Count set value 64b
-data modify block -587 52 1951 Items[2].Count set value 64b
-data modify block -587 52 1951 Items[3].Count set value 64b
-data modify block -587 52 1951 Items[4].Count set value 64b
-data modify block -587 52 1951 Items[5].Count set value 64b
-data modify block -587 52 1951 Items[6].Count set value 64b
-data modify block -587 52 1951 Items[7].Count set value 64b
-data modify block -587 52 1951 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -589 11 2032 Items[0].Count set value 64b
-data modify block -589 11 2032 Items[1].Count set value 64b
-data modify block -589 11 2032 Items[2].Count set value 64b
-data modify block -589 11 2032 Items[3].Count set value 64b
-data modify block -589 11 2032 Items[4].Count set value 64b
-data modify block -589 11 2032 Items[5].Count set value 64b
-data modify block -589 11 2032 Items[6].Count set value 64b
-data modify block -589 11 2032 Items[7].Count set value 64b
-data modify block -589 11 2032 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -589 46 1978 Items[0].Count set value 64b
-data modify block -589 46 1978 Items[1].Count set value 64b
-data modify block -589 46 1978 Items[2].Count set value 64b
-data modify block -589 46 1978 Items[3].Count set value 64b
-data modify block -589 46 1978 Items[4].Count set value 64b
-data modify block -589 46 1978 Items[5].Count set value 64b
-data modify block -589 46 1978 Items[6].Count set value 64b
-data modify block -589 46 1978 Items[7].Count set value 64b
-data modify block -589 46 1978 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -591 1 1901 Items[0].Count set value 64b
-data modify block -591 1 1901 Items[1].Count set value 64b
-data modify block -591 1 1901 Items[2].Count set value 64b
-data modify block -591 1 1901 Items[3].Count set value 64b
-data modify block -591 1 1901 Items[4].Count set value 64b
-data modify block -591 1 1901 Items[5].Count set value 64b
-data modify block -591 1 1901 Items[6].Count set value 64b
-data modify block -591 1 1901 Items[7].Count set value 64b
-data modify block -591 1 1901 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -598 11 1989 Items[0].Count set value 64b
-data modify block -598 11 1989 Items[1].Count set value 64b
-data modify block -598 11 1989 Items[2].Count set value 64b
-data modify block -598 11 1989 Items[3].Count set value 64b
-data modify block -598 11 1989 Items[4].Count set value 64b
-data modify block -598 11 1989 Items[5].Count set value 64b
-data modify block -598 11 1989 Items[6].Count set value 64b
-data modify block -598 11 1989 Items[7].Count set value 64b
-data modify block -598 11 1989 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -599 12 2009 Items[0].Count set value 64b
-data modify block -599 12 2009 Items[1].Count set value 64b
-data modify block -599 12 2009 Items[2].Count set value 64b
-data modify block -599 12 2009 Items[3].Count set value 64b
-data modify block -599 12 2009 Items[4].Count set value 64b
-data modify block -599 12 2009 Items[5].Count set value 64b
-data modify block -599 12 2009 Items[6].Count set value 64b
-data modify block -599 12 2009 Items[7].Count set value 64b
-data modify block -599 12 2009 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -602 -9 1885 Items[0].Count set value 64b
-data modify block -602 -9 1885 Items[1].Count set value 64b
-data modify block -602 -9 1885 Items[2].Count set value 64b
-data modify block -602 -9 1885 Items[3].Count set value 64b
-data modify block -602 -9 1885 Items[4].Count set value 64b
-data modify block -602 -9 1885 Items[5].Count set value 64b
-data modify block -602 -9 1885 Items[6].Count set value 64b
-data modify block -602 -9 1885 Items[7].Count set value 64b
-data modify block -602 -9 1885 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -606 1 1921 Items[0].Count set value 64b
-data modify block -606 1 1921 Items[1].Count set value 64b
-data modify block -606 1 1921 Items[2].Count set value 64b
-data modify block -606 1 1921 Items[3].Count set value 64b
-data modify block -606 1 1921 Items[4].Count set value 64b
-data modify block -606 1 1921 Items[5].Count set value 64b
-data modify block -606 1 1921 Items[6].Count set value 64b
-data modify block -606 1 1921 Items[7].Count set value 64b
-data modify block -606 1 1921 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -606 43 2023 Items[0].Count set value 64b
-data modify block -606 43 2023 Items[1].Count set value 64b
-data modify block -606 43 2023 Items[2].Count set value 64b
-data modify block -606 43 2023 Items[3].Count set value 64b
-data modify block -606 43 2023 Items[4].Count set value 64b
-data modify block -606 43 2023 Items[5].Count set value 64b
-data modify block -606 43 2023 Items[6].Count set value 64b
-data modify block -606 43 2023 Items[7].Count set value 64b
-data modify block -606 43 2023 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -609 -19 1919 Items[0].Count set value 64b
-data modify block -609 -19 1919 Items[1].Count set value 64b
-data modify block -609 -19 1919 Items[2].Count set value 64b
-data modify block -609 -19 1919 Items[3].Count set value 64b
-data modify block -609 -19 1919 Items[4].Count set value 64b
-data modify block -609 -19 1919 Items[5].Count set value 64b
-data modify block -609 -19 1919 Items[6].Count set value 64b
-data modify block -609 -19 1919 Items[7].Count set value 64b
-data modify block -609 -19 1919 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -619 43 2026 Items[0].Count set value 64b
-data modify block -619 43 2026 Items[1].Count set value 64b
-data modify block -619 43 2026 Items[2].Count set value 64b
-data modify block -619 43 2026 Items[3].Count set value 64b
-data modify block -619 43 2026 Items[4].Count set value 64b
-data modify block -619 43 2026 Items[5].Count set value 64b
-data modify block -619 43 2026 Items[6].Count set value 64b
-data modify block -619 43 2026 Items[7].Count set value 64b
-data modify block -619 43 2026 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -623 -9 1924 Items[0].Count set value 64b
-data modify block -623 -9 1924 Items[1].Count set value 64b
-data modify block -623 -9 1924 Items[2].Count set value 64b
-data modify block -623 -9 1924 Items[3].Count set value 64b
-data modify block -623 -9 1924 Items[4].Count set value 64b
-data modify block -623 -9 1924 Items[5].Count set value 64b
-data modify block -623 -9 1924 Items[6].Count set value 64b
-data modify block -623 -9 1924 Items[7].Count set value 64b
-data modify block -623 -9 1924 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -628 1 1921 Items[0].Count set value 64b
-data modify block -628 1 1921 Items[1].Count set value 64b
-data modify block -628 1 1921 Items[2].Count set value 64b
-data modify block -628 1 1921 Items[3].Count set value 64b
-data modify block -628 1 1921 Items[4].Count set value 64b
-data modify block -628 1 1921 Items[5].Count set value 64b
-data modify block -628 1 1921 Items[6].Count set value 64b
-data modify block -628 1 1921 Items[7].Count set value 64b
-data modify block -628 1 1921 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1952 Items[0].Count set value 64b
-data modify block -633 -20 1952 Items[1].Count set value 64b
-data modify block -633 -20 1952 Items[2].Count set value 64b
-data modify block -633 -20 1952 Items[3].Count set value 64b
-data modify block -633 -20 1952 Items[4].Count set value 64b
-data modify block -633 -20 1952 Items[5].Count set value 64b
-data modify block -633 -20 1952 Items[6].Count set value 64b
-data modify block -633 -20 1952 Items[7].Count set value 64b
-data modify block -633 -20 1952 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1953 Items[0].Count set value 64b
-data modify block -633 -20 1953 Items[1].Count set value 64b
-data modify block -633 -20 1953 Items[2].Count set value 64b
-data modify block -633 -20 1953 Items[3].Count set value 64b
-data modify block -633 -20 1953 Items[4].Count set value 64b
-data modify block -633 -20 1953 Items[5].Count set value 64b
-data modify block -633 -20 1953 Items[6].Count set value 64b
-data modify block -633 -20 1953 Items[7].Count set value 64b
-data modify block -633 -20 1953 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1954 Items[0].Count set value 64b
-data modify block -633 -20 1954 Items[1].Count set value 64b
-data modify block -633 -20 1954 Items[2].Count set value 64b
-data modify block -633 -20 1954 Items[3].Count set value 64b
-data modify block -633 -20 1954 Items[4].Count set value 64b
-data modify block -633 -20 1954 Items[5].Count set value 64b
-data modify block -633 -20 1954 Items[6].Count set value 64b
-data modify block -633 -20 1954 Items[7].Count set value 64b
-data modify block -633 -20 1954 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1955 Items[0].Count set value 64b
-data modify block -633 -20 1955 Items[1].Count set value 64b
-data modify block -633 -20 1955 Items[2].Count set value 64b
-data modify block -633 -20 1955 Items[3].Count set value 64b
-data modify block -633 -20 1955 Items[4].Count set value 64b
-data modify block -633 -20 1955 Items[5].Count set value 64b
-data modify block -633 -20 1955 Items[6].Count set value 64b
-data modify block -633 -20 1955 Items[7].Count set value 64b
-data modify block -633 -20 1955 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1956 Items[0].Count set value 64b
-data modify block -633 -20 1956 Items[1].Count set value 64b
-data modify block -633 -20 1956 Items[2].Count set value 64b
-data modify block -633 -20 1956 Items[3].Count set value 64b
-data modify block -633 -20 1956 Items[4].Count set value 64b
-data modify block -633 -20 1956 Items[5].Count set value 64b
-data modify block -633 -20 1956 Items[6].Count set value 64b
-data modify block -633 -20 1956 Items[7].Count set value 64b
-data modify block -633 -20 1956 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1957 Items[0].Count set value 64b
-data modify block -633 -20 1957 Items[1].Count set value 64b
-data modify block -633 -20 1957 Items[2].Count set value 64b
-data modify block -633 -20 1957 Items[3].Count set value 64b
-data modify block -633 -20 1957 Items[4].Count set value 64b
-data modify block -633 -20 1957 Items[5].Count set value 64b
-data modify block -633 -20 1957 Items[6].Count set value 64b
-data modify block -633 -20 1957 Items[7].Count set value 64b
-data modify block -633 -20 1957 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1958 Items[0].Count set value 64b
-data modify block -633 -20 1958 Items[1].Count set value 64b
-data modify block -633 -20 1958 Items[2].Count set value 64b
-data modify block -633 -20 1958 Items[3].Count set value 64b
-data modify block -633 -20 1958 Items[4].Count set value 64b
-data modify block -633 -20 1958 Items[5].Count set value 64b
-data modify block -633 -20 1958 Items[6].Count set value 64b
-data modify block -633 -20 1958 Items[7].Count set value 64b
-data modify block -633 -20 1958 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1959 Items[0].Count set value 64b
-data modify block -633 -20 1959 Items[1].Count set value 64b
-data modify block -633 -20 1959 Items[2].Count set value 64b
-data modify block -633 -20 1959 Items[3].Count set value 64b
-data modify block -633 -20 1959 Items[4].Count set value 64b
-data modify block -633 -20 1959 Items[5].Count set value 64b
-data modify block -633 -20 1959 Items[6].Count set value 64b
-data modify block -633 -20 1959 Items[7].Count set value 64b
-data modify block -633 -20 1959 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1960 Items[0].Count set value 64b
-data modify block -633 -20 1960 Items[1].Count set value 64b
-data modify block -633 -20 1960 Items[2].Count set value 64b
-data modify block -633 -20 1960 Items[3].Count set value 64b
-data modify block -633 -20 1960 Items[4].Count set value 64b
-data modify block -633 -20 1960 Items[5].Count set value 64b
-data modify block -633 -20 1960 Items[6].Count set value 64b
-data modify block -633 -20 1960 Items[7].Count set value 64b
-data modify block -633 -20 1960 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1961 Items[0].Count set value 64b
-data modify block -633 -20 1961 Items[1].Count set value 64b
-data modify block -633 -20 1961 Items[2].Count set value 64b
-data modify block -633 -20 1961 Items[3].Count set value 64b
-data modify block -633 -20 1961 Items[4].Count set value 64b
-data modify block -633 -20 1961 Items[5].Count set value 64b
-data modify block -633 -20 1961 Items[6].Count set value 64b
-data modify block -633 -20 1961 Items[7].Count set value 64b
-data modify block -633 -20 1961 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1962 Items[0].Count set value 64b
-data modify block -633 -20 1962 Items[1].Count set value 64b
-data modify block -633 -20 1962 Items[2].Count set value 64b
-data modify block -633 -20 1962 Items[3].Count set value 64b
-data modify block -633 -20 1962 Items[4].Count set value 64b
-data modify block -633 -20 1962 Items[5].Count set value 64b
-data modify block -633 -20 1962 Items[6].Count set value 64b
-data modify block -633 -20 1962 Items[7].Count set value 64b
-data modify block -633 -20 1962 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1963 Items[0].Count set value 64b
-data modify block -633 -20 1963 Items[1].Count set value 64b
-data modify block -633 -20 1963 Items[2].Count set value 64b
-data modify block -633 -20 1963 Items[3].Count set value 64b
-data modify block -633 -20 1963 Items[4].Count set value 64b
-data modify block -633 -20 1963 Items[5].Count set value 64b
-data modify block -633 -20 1963 Items[6].Count set value 64b
-data modify block -633 -20 1963 Items[7].Count set value 64b
-data modify block -633 -20 1963 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1964 Items[0].Count set value 64b
-data modify block -633 -20 1964 Items[1].Count set value 64b
-data modify block -633 -20 1964 Items[2].Count set value 64b
-data modify block -633 -20 1964 Items[3].Count set value 64b
-data modify block -633 -20 1964 Items[4].Count set value 64b
-data modify block -633 -20 1964 Items[5].Count set value 64b
-data modify block -633 -20 1964 Items[6].Count set value 64b
-data modify block -633 -20 1964 Items[7].Count set value 64b
-data modify block -633 -20 1964 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1965 Items[0].Count set value 64b
-data modify block -633 -20 1965 Items[1].Count set value 64b
-data modify block -633 -20 1965 Items[2].Count set value 64b
-data modify block -633 -20 1965 Items[3].Count set value 64b
-data modify block -633 -20 1965 Items[4].Count set value 64b
-data modify block -633 -20 1965 Items[5].Count set value 64b
-data modify block -633 -20 1965 Items[6].Count set value 64b
-data modify block -633 -20 1965 Items[7].Count set value 64b
-data modify block -633 -20 1965 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1966 Items[0].Count set value 64b
-data modify block -633 -20 1966 Items[1].Count set value 64b
-data modify block -633 -20 1966 Items[2].Count set value 64b
-data modify block -633 -20 1966 Items[3].Count set value 64b
-data modify block -633 -20 1966 Items[4].Count set value 64b
-data modify block -633 -20 1966 Items[5].Count set value 64b
-data modify block -633 -20 1966 Items[6].Count set value 64b
-data modify block -633 -20 1966 Items[7].Count set value 64b
-data modify block -633 -20 1966 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1967 Items[0].Count set value 64b
-data modify block -633 -20 1967 Items[1].Count set value 64b
-data modify block -633 -20 1967 Items[2].Count set value 64b
-data modify block -633 -20 1967 Items[3].Count set value 64b
-data modify block -633 -20 1967 Items[4].Count set value 64b
-data modify block -633 -20 1967 Items[5].Count set value 64b
-data modify block -633 -20 1967 Items[6].Count set value 64b
-data modify block -633 -20 1967 Items[7].Count set value 64b
-data modify block -633 -20 1967 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1968 Items[0].Count set value 64b
-data modify block -633 -20 1968 Items[1].Count set value 64b
-data modify block -633 -20 1968 Items[2].Count set value 64b
-data modify block -633 -20 1968 Items[3].Count set value 64b
-data modify block -633 -20 1968 Items[4].Count set value 64b
-data modify block -633 -20 1968 Items[5].Count set value 64b
-data modify block -633 -20 1968 Items[6].Count set value 64b
-data modify block -633 -20 1968 Items[7].Count set value 64b
-data modify block -633 -20 1968 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1969 Items[0].Count set value 64b
-data modify block -633 -20 1969 Items[1].Count set value 64b
-data modify block -633 -20 1969 Items[2].Count set value 64b
-data modify block -633 -20 1969 Items[3].Count set value 64b
-data modify block -633 -20 1969 Items[4].Count set value 64b
-data modify block -633 -20 1969 Items[5].Count set value 64b
-data modify block -633 -20 1969 Items[6].Count set value 64b
-data modify block -633 -20 1969 Items[7].Count set value 64b
-data modify block -633 -20 1969 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1970 Items[0].Count set value 64b
-data modify block -633 -20 1970 Items[1].Count set value 64b
-data modify block -633 -20 1970 Items[2].Count set value 64b
-data modify block -633 -20 1970 Items[3].Count set value 64b
-data modify block -633 -20 1970 Items[4].Count set value 64b
-data modify block -633 -20 1970 Items[5].Count set value 64b
-data modify block -633 -20 1970 Items[6].Count set value 64b
-data modify block -633 -20 1970 Items[7].Count set value 64b
-data modify block -633 -20 1970 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1971 Items[0].Count set value 64b
-data modify block -633 -20 1971 Items[1].Count set value 64b
-data modify block -633 -20 1971 Items[2].Count set value 64b
-data modify block -633 -20 1971 Items[3].Count set value 64b
-data modify block -633 -20 1971 Items[4].Count set value 64b
-data modify block -633 -20 1971 Items[5].Count set value 64b
-data modify block -633 -20 1971 Items[6].Count set value 64b
-data modify block -633 -20 1971 Items[7].Count set value 64b
-data modify block -633 -20 1971 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1972 Items[0].Count set value 64b
-data modify block -633 -20 1972 Items[1].Count set value 64b
-data modify block -633 -20 1972 Items[2].Count set value 64b
-data modify block -633 -20 1972 Items[3].Count set value 64b
-data modify block -633 -20 1972 Items[4].Count set value 64b
-data modify block -633 -20 1972 Items[5].Count set value 64b
-data modify block -633 -20 1972 Items[6].Count set value 64b
-data modify block -633 -20 1972 Items[7].Count set value 64b
-data modify block -633 -20 1972 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1973 Items[0].Count set value 64b
-data modify block -633 -20 1973 Items[1].Count set value 64b
-data modify block -633 -20 1973 Items[2].Count set value 64b
-data modify block -633 -20 1973 Items[3].Count set value 64b
-data modify block -633 -20 1973 Items[4].Count set value 64b
-data modify block -633 -20 1973 Items[5].Count set value 64b
-data modify block -633 -20 1973 Items[6].Count set value 64b
-data modify block -633 -20 1973 Items[7].Count set value 64b
-data modify block -633 -20 1973 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1974 Items[0].Count set value 64b
-data modify block -633 -20 1974 Items[1].Count set value 64b
-data modify block -633 -20 1974 Items[2].Count set value 64b
-data modify block -633 -20 1974 Items[3].Count set value 64b
-data modify block -633 -20 1974 Items[4].Count set value 64b
-data modify block -633 -20 1974 Items[5].Count set value 64b
-data modify block -633 -20 1974 Items[6].Count set value 64b
-data modify block -633 -20 1974 Items[7].Count set value 64b
-data modify block -633 -20 1974 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1975 Items[0].Count set value 64b
-data modify block -633 -20 1975 Items[1].Count set value 64b
-data modify block -633 -20 1975 Items[2].Count set value 64b
-data modify block -633 -20 1975 Items[3].Count set value 64b
-data modify block -633 -20 1975 Items[4].Count set value 64b
-data modify block -633 -20 1975 Items[5].Count set value 64b
-data modify block -633 -20 1975 Items[6].Count set value 64b
-data modify block -633 -20 1975 Items[7].Count set value 64b
-data modify block -633 -20 1975 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1976 Items[0].Count set value 64b
-data modify block -633 -20 1976 Items[1].Count set value 64b
-data modify block -633 -20 1976 Items[2].Count set value 64b
-data modify block -633 -20 1976 Items[3].Count set value 64b
-data modify block -633 -20 1976 Items[4].Count set value 64b
-data modify block -633 -20 1976 Items[5].Count set value 64b
-data modify block -633 -20 1976 Items[6].Count set value 64b
-data modify block -633 -20 1976 Items[7].Count set value 64b
-data modify block -633 -20 1976 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1977 Items[0].Count set value 64b
-data modify block -633 -20 1977 Items[1].Count set value 64b
-data modify block -633 -20 1977 Items[2].Count set value 64b
-data modify block -633 -20 1977 Items[3].Count set value 64b
-data modify block -633 -20 1977 Items[4].Count set value 64b
-data modify block -633 -20 1977 Items[5].Count set value 64b
-data modify block -633 -20 1977 Items[6].Count set value 64b
-data modify block -633 -20 1977 Items[7].Count set value 64b
-data modify block -633 -20 1977 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1978 Items[0].Count set value 64b
-data modify block -633 -20 1978 Items[1].Count set value 64b
-data modify block -633 -20 1978 Items[2].Count set value 64b
-data modify block -633 -20 1978 Items[3].Count set value 64b
-data modify block -633 -20 1978 Items[4].Count set value 64b
-data modify block -633 -20 1978 Items[5].Count set value 64b
-data modify block -633 -20 1978 Items[6].Count set value 64b
-data modify block -633 -20 1978 Items[7].Count set value 64b
-data modify block -633 -20 1978 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -633 -20 1979 Items[0].Count set value 64b
-data modify block -633 -20 1979 Items[1].Count set value 64b
-data modify block -633 -20 1979 Items[2].Count set value 64b
-data modify block -633 -20 1979 Items[3].Count set value 64b
-data modify block -633 -20 1979 Items[4].Count set value 64b
-data modify block -633 -20 1979 Items[5].Count set value 64b
-data modify block -633 -20 1979 Items[6].Count set value 64b
-data modify block -633 -20 1979 Items[7].Count set value 64b
-data modify block -633 -20 1979 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -640 -19 1889 Items[0].Count set value 64b
-data modify block -640 -19 1889 Items[1].Count set value 64b
-data modify block -640 -19 1889 Items[2].Count set value 64b
-data modify block -640 -19 1889 Items[3].Count set value 64b
-data modify block -640 -19 1889 Items[4].Count set value 64b
-data modify block -640 -19 1889 Items[5].Count set value 64b
-data modify block -640 -19 1889 Items[6].Count set value 64b
-data modify block -640 -19 1889 Items[7].Count set value 64b
-data modify block -640 -19 1889 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -642 -19 1921 Items[0].Count set value 64b
-data modify block -642 -19 1921 Items[1].Count set value 64b
-data modify block -642 -19 1921 Items[2].Count set value 64b
-data modify block -642 -19 1921 Items[3].Count set value 64b
-data modify block -642 -19 1921 Items[4].Count set value 64b
-data modify block -642 -19 1921 Items[5].Count set value 64b
-data modify block -642 -19 1921 Items[6].Count set value 64b
-data modify block -642 -19 1921 Items[7].Count set value 64b
-data modify block -642 -19 1921 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -644 1 1921 Items[0].Count set value 64b
-data modify block -644 1 1921 Items[1].Count set value 64b
-data modify block -644 1 1921 Items[2].Count set value 64b
-data modify block -644 1 1921 Items[3].Count set value 64b
-data modify block -644 1 1921 Items[4].Count set value 64b
-data modify block -644 1 1921 Items[5].Count set value 64b
-data modify block -644 1 1921 Items[6].Count set value 64b
-data modify block -644 1 1921 Items[7].Count set value 64b
-data modify block -644 1 1921 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -652 1 1892 Items[0].Count set value 64b
-data modify block -652 1 1892 Items[1].Count set value 64b
-data modify block -652 1 1892 Items[2].Count set value 64b
-data modify block -652 1 1892 Items[3].Count set value 64b
-data modify block -652 1 1892 Items[4].Count set value 64b
-data modify block -652 1 1892 Items[5].Count set value 64b
-data modify block -652 1 1892 Items[6].Count set value 64b
-data modify block -652 1 1892 Items[7].Count set value 64b
-data modify block -652 1 1892 Items[8].Count set value 64b
-
-## Example Item: "Decked Out Frost Ember"
-data modify block -654 -9 1892 Items[0].Count set value 64b
-data modify block -654 -9 1892 Items[1].Count set value 64b
-data modify block -654 -9 1892 Items[2].Count set value 64b
-data modify block -654 -9 1892 Items[3].Count set value 64b
-data modify block -654 -9 1892 Items[4].Count set value 64b
-data modify block -654 -9 1892 Items[5].Count set value 64b
-data modify block -654 -9 1892 Items[6].Count set value 64b
-data modify block -654 -9 1892 Items[7].Count set value 64b
-data modify block -654 -9 1892 Items[8].Count set value 64b
+data modify block -478 19 2009 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -484 53 1988 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -485 31 1962 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -489 11 2007 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -490 50 2016 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -496 15 1999 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -498 51 1980 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -501 16 1972 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -502 31 1975 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -508 9 1951 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -509 14 2033 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -513 51 1962 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -515 46 2031 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -518 2 2007 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -518 53 2011 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -518 53 2011 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -519 35 2002 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -521 35 1981 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -526 12 1941 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -527 51 1974 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -528 12 2032 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -531 16 1989 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -533 44 2024 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -537 45 1948 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -542 11 1998 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -545 51 2008 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -548 11 1976 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -553 10 2037 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -554 51 2008 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -558 45 1976 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -558 46 2022 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -560 47 1942 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -565 36 1999 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -569 8 1964 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -573 11 2007 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -573 36 1998 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -579 -37 1835 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -582 13 1934 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -582 13 1935 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -582 13 1936 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -582 13 1937 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -582 9 1955 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -583 45 2013 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -584 -17 1927 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -584 13 1934 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -584 13 1935 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -584 13 1936 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -584 13 1937 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -585 -9 1920 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -586 1 1888 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -587 52 1951 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -589 11 2032 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -589 46 1978 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -591 1 1901 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -598 11 1989 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -599 12 2009 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -602 -9 1885 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -606 1 1921 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -606 43 2023 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -609 -19 1919 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -619 43 2026 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -623 -9 1924 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -628 1 1921 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1952 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1953 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1954 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1955 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1956 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1957 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1958 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1959 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1960 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1961 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1962 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1963 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1964 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1965 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1966 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1967 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1968 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1969 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1970 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1971 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1972 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1973 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1974 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1975 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1976 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1977 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1978 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -633 -20 1979 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -640 -19 1889 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -642 -19 1921 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -644 1 1921 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -652 1 1892 Items[].Count set value 64b
+
+## Example Item: "Decked Out Frost Ember"
+data modify block -654 -9 1892 Items[].Count set value 64b
 
 # Category "Other Items"
 ## Example Item: "The Bomb"
-data modify block -569 -48 1909 Items[0].Count set value 64b
-data modify block -569 -48 1909 Items[1].Count set value 64b
-data modify block -569 -48 1909 Items[2].Count set value 64b
-data modify block -569 -48 1909 Items[3].Count set value 64b
-data modify block -569 -48 1909 Items[4].Count set value 64b
-data modify block -569 -48 1909 Items[5].Count set value 64b
-data modify block -569 -48 1909 Items[6].Count set value 64b
-data modify block -569 -48 1909 Items[7].Count set value 64b
-data modify block -569 -48 1909 Items[8].Count set value 64b
+data modify block -569 -48 1909 Items[].Count set value 64b
 
 ## Example Item: "The Bomb"
-data modify block -598 -51 1876 Items[0].Count set value 64b
-data modify block -598 -51 1876 Items[1].Count set value 64b
-data modify block -598 -51 1876 Items[2].Count set value 64b
-data modify block -598 -51 1876 Items[3].Count set value 64b
-data modify block -598 -51 1876 Items[4].Count set value 64b
-data modify block -598 -51 1876 Items[5].Count set value 64b
-data modify block -598 -51 1876 Items[6].Count set value 64b
-data modify block -598 -51 1876 Items[7].Count set value 64b
-data modify block -598 -51 1876 Items[8].Count set value 64b
+data modify block -598 -51 1876 Items[].Count set value 64b
 
 ## Example Item: "The Bomb"
-data modify block -602 -51 1843 Items[0].Count set value 64b
-data modify block -602 -51 1843 Items[1].Count set value 64b
-data modify block -602 -51 1843 Items[2].Count set value 64b
-data modify block -602 -51 1843 Items[3].Count set value 64b
-data modify block -602 -51 1843 Items[4].Count set value 64b
-data modify block -602 -51 1843 Items[5].Count set value 64b
-data modify block -602 -51 1843 Items[6].Count set value 64b
-data modify block -602 -51 1843 Items[7].Count set value 64b
-data modify block -602 -51 1843 Items[8].Count set value 64b
+data modify block -602 -51 1843 Items[].Count set value 64b
 
 ## Example Item: "The Bomb"
-data modify block -605 -49 1910 Items[0].Count set value 64b
-data modify block -605 -49 1910 Items[1].Count set value 64b
-data modify block -605 -49 1910 Items[2].Count set value 64b
-data modify block -605 -49 1910 Items[3].Count set value 64b
-data modify block -605 -49 1910 Items[4].Count set value 64b
-data modify block -605 -49 1910 Items[5].Count set value 64b
-data modify block -605 -49 1910 Items[6].Count set value 64b
-data modify block -605 -49 1910 Items[7].Count set value 64b
-data modify block -605 -49 1910 Items[8].Count set value 64b
+data modify block -605 -49 1910 Items[].Count set value 64b
 
 ## Example Item: "The Bomb"
-data modify block -637 -51 1872 Items[0].Count set value 64b
-data modify block -637 -51 1872 Items[1].Count set value 64b
-data modify block -637 -51 1872 Items[2].Count set value 64b
-data modify block -637 -51 1872 Items[3].Count set value 64b
-data modify block -637 -51 1872 Items[4].Count set value 64b
-data modify block -637 -51 1872 Items[5].Count set value 64b
-data modify block -637 -51 1872 Items[6].Count set value 64b
-data modify block -637 -51 1872 Items[7].Count set value 64b
-data modify block -637 -51 1872 Items[8].Count set value 64b
+data modify block -637 -51 1872 Items[].Count set value 64b
 
 ## Example Item: "Victory Tome"
-data modify block -644 -20 1992 Items[0].Count set value 64b
-data modify block -644 -20 1992 Items[1].Count set value 64b
-data modify block -644 -20 1992 Items[2].Count set value 64b
-data modify block -644 -20 1992 Items[3].Count set value 64b
-data modify block -644 -20 1992 Items[4].Count set value 64b
-data modify block -644 -20 1992 Items[5].Count set value 64b
-data modify block -644 -20 1992 Items[6].Count set value 64b
-data modify block -644 -20 1992 Items[7].Count set value 64b
-data modify block -644 -20 1992 Items[8].Count set value 64b
+data modify block -644 -20 1992 Items[].Count set value 64b
 
 ## Example Item: "Victory Tome"
-data modify block -644 -20 1994 Items[0].Count set value 64b
-data modify block -644 -20 1994 Items[1].Count set value 64b
-data modify block -644 -20 1994 Items[2].Count set value 64b
-data modify block -644 -20 1994 Items[3].Count set value 64b
-data modify block -644 -20 1994 Items[4].Count set value 64b
-data modify block -644 -20 1994 Items[5].Count set value 64b
-data modify block -644 -20 1994 Items[6].Count set value 64b
-data modify block -644 -20 1994 Items[7].Count set value 64b
-data modify block -644 -20 1994 Items[8].Count set value 64b
+data modify block -644 -20 1994 Items[].Count set value 64b
 
 ## Example Item: "Victory Tome"
-data modify block -644 -20 1996 Items[0].Count set value 64b
-data modify block -644 -20 1996 Items[1].Count set value 64b
-data modify block -644 -20 1996 Items[2].Count set value 64b
-data modify block -644 -20 1996 Items[3].Count set value 64b
-data modify block -644 -20 1996 Items[4].Count set value 64b
-data modify block -644 -20 1996 Items[5].Count set value 64b
-data modify block -644 -20 1996 Items[6].Count set value 64b
-data modify block -644 -20 1996 Items[7].Count set value 64b
-data modify block -644 -20 1996 Items[8].Count set value 64b
+data modify block -644 -20 1996 Items[].Count set value 64b
 
 ## Example Item: "minecraft:cooked_porkchop"
-data modify block -627 59 1945 Items[0].Count set value 64b
-data modify block -627 59 1945 Items[1].Count set value 64b
-data modify block -627 59 1945 Items[2].Count set value 64b
-data modify block -627 59 1945 Items[3].Count set value 64b
-data modify block -627 59 1945 Items[4].Count set value 64b
-data modify block -627 59 1945 Items[5].Count set value 64b
-data modify block -627 59 1945 Items[6].Count set value 64b
-data modify block -627 59 1945 Items[7].Count set value 64b
-data modify block -627 59 1945 Items[8].Count set value 64b
+data modify block -627 59 1945 Items[].Count set value 64b
 
 ## Example Item: "minecraft:diamond_chestplate"
-data modify block -629 59 1945 Items[0].Count set value 64b
-data modify block -629 59 1945 Items[1].Count set value 64b
-data modify block -629 59 1945 Items[2].Count set value 64b
-data modify block -629 59 1945 Items[3].Count set value 64b
-data modify block -629 59 1945 Items[4].Count set value 64b
-data modify block -629 59 1945 Items[5].Count set value 64b
-data modify block -629 59 1945 Items[6].Count set value 64b
-data modify block -629 59 1945 Items[7].Count set value 64b
-data modify block -629 59 1945 Items[8].Count set value 64b
+data modify block -629 59 1945 Items[].Count set value 64b
 
 ## Example Item: "minecraft:diamond_leggings"
-data modify block -630 59 1945 Items[0].Count set value 64b
-data modify block -630 59 1945 Items[1].Count set value 64b
-data modify block -630 59 1945 Items[2].Count set value 64b
-data modify block -630 59 1945 Items[3].Count set value 64b
-data modify block -630 59 1945 Items[4].Count set value 64b
-data modify block -630 59 1945 Items[5].Count set value 64b
-data modify block -630 59 1945 Items[6].Count set value 64b
-data modify block -630 59 1945 Items[7].Count set value 64b
-data modify block -630 59 1945 Items[8].Count set value 64b
+data modify block -630 59 1945 Items[].Count set value 64b
 
 ## Example Item: "minecraft:filled_map"
-data modify block -625 59 1945 Items[0].Count set value 64b
-data modify block -625 59 1945 Items[1].Count set value 64b
-data modify block -625 59 1945 Items[2].Count set value 64b
-data modify block -625 59 1945 Items[3].Count set value 64b
-data modify block -625 59 1945 Items[4].Count set value 64b
-data modify block -625 59 1945 Items[5].Count set value 64b
-data modify block -625 59 1945 Items[6].Count set value 64b
-data modify block -625 59 1945 Items[7].Count set value 64b
-data modify block -625 59 1945 Items[8].Count set value 64b
+data modify block -625 59 1945 Items[].Count set value 64b
 
 ## Example Item: "minecraft:tnt"
-data modify block -579 -39 1843 Items[0].Count set value 64b
-data modify block -579 -39 1843 Items[1].Count set value 64b
-data modify block -579 -39 1843 Items[2].Count set value 64b
-data modify block -579 -39 1843 Items[3].Count set value 64b
-data modify block -579 -39 1843 Items[4].Count set value 64b
-data modify block -579 -39 1843 Items[5].Count set value 64b
-data modify block -579 -39 1843 Items[6].Count set value 64b
-data modify block -579 -39 1843 Items[7].Count set value 64b
-data modify block -579 -39 1843 Items[8].Count set value 64b
+data modify block -579 -39 1843 Items[].Count set value 64b
 
 ## Example Item: "minecraft:tnt"
-data modify block -640 17 1904 Items[0].Count set value 64b
-data modify block -640 17 1904 Items[1].Count set value 64b
-data modify block -640 17 1904 Items[2].Count set value 64b
-data modify block -640 17 1904 Items[3].Count set value 64b
-data modify block -640 17 1904 Items[4].Count set value 64b
-data modify block -640 17 1904 Items[5].Count set value 64b
-data modify block -640 17 1904 Items[6].Count set value 64b
-data modify block -640 17 1904 Items[7].Count set value 64b
-data modify block -640 17 1904 Items[8].Count set value 64b
+data modify block -640 17 1904 Items[].Count set value 64b
 
 # Category "Suit Up Armor"
 ## Example Item: "minecraft:diamond_chestplate"
-data modify block -629 59 1945 Items[0].Count set value 64b
-data modify block -629 59 1945 Items[1].Count set value 64b
-data modify block -629 59 1945 Items[2].Count set value 64b
-data modify block -629 59 1945 Items[3].Count set value 64b
-data modify block -629 59 1945 Items[4].Count set value 64b
-data modify block -629 59 1945 Items[5].Count set value 64b
-data modify block -629 59 1945 Items[6].Count set value 64b
-data modify block -629 59 1945 Items[7].Count set value 64b
-data modify block -629 59 1945 Items[8].Count set value 64b
+data modify block -629 59 1945 Items[].Count set value 64b
 
 ## Example Item: "minecraft:diamond_leggings"
-data modify block -630 59 1945 Items[0].Count set value 64b
-data modify block -630 59 1945 Items[1].Count set value 64b
-data modify block -630 59 1945 Items[2].Count set value 64b
-data modify block -630 59 1945 Items[3].Count set value 64b
-data modify block -630 59 1945 Items[4].Count set value 64b
-data modify block -630 59 1945 Items[5].Count set value 64b
-data modify block -630 59 1945 Items[6].Count set value 64b
-data modify block -630 59 1945 Items[7].Count set value 64b
-data modify block -630 59 1945 Items[8].Count set value 64b
+data modify block -630 59 1945 Items[].Count set value 64b
 
 # Category "Treasure"
 ## Example Item: "Decked Out Coin"
-data modify block -479 19 2009 Items[0].Count set value 64b
-data modify block -479 19 2009 Items[1].Count set value 64b
-data modify block -479 19 2009 Items[2].Count set value 64b
-data modify block -479 19 2009 Items[3].Count set value 64b
-data modify block -479 19 2009 Items[4].Count set value 64b
-data modify block -479 19 2009 Items[5].Count set value 64b
-data modify block -479 19 2009 Items[6].Count set value 64b
-data modify block -479 19 2009 Items[7].Count set value 64b
-data modify block -479 19 2009 Items[8].Count set value 64b
+data modify block -479 19 2009 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -484 53 1989 Items[0].Count set value 64b
-data modify block -484 53 1989 Items[1].Count set value 64b
-data modify block -484 53 1989 Items[2].Count set value 64b
-data modify block -484 53 1989 Items[3].Count set value 64b
-data modify block -484 53 1989 Items[4].Count set value 64b
-data modify block -484 53 1989 Items[5].Count set value 64b
-data modify block -484 53 1989 Items[6].Count set value 64b
-data modify block -484 53 1989 Items[7].Count set value 64b
-data modify block -484 53 1989 Items[8].Count set value 64b
+data modify block -484 53 1989 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -485 31 1963 Items[0].Count set value 64b
-data modify block -485 31 1963 Items[1].Count set value 64b
-data modify block -485 31 1963 Items[2].Count set value 64b
-data modify block -485 31 1963 Items[3].Count set value 64b
-data modify block -485 31 1963 Items[4].Count set value 64b
-data modify block -485 31 1963 Items[5].Count set value 64b
-data modify block -485 31 1963 Items[6].Count set value 64b
-data modify block -485 31 1963 Items[7].Count set value 64b
-data modify block -485 31 1963 Items[8].Count set value 64b
+data modify block -485 31 1963 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -490 11 2007 Items[0].Count set value 64b
-data modify block -490 11 2007 Items[1].Count set value 64b
-data modify block -490 11 2007 Items[2].Count set value 64b
-data modify block -490 11 2007 Items[3].Count set value 64b
-data modify block -490 11 2007 Items[4].Count set value 64b
-data modify block -490 11 2007 Items[5].Count set value 64b
-data modify block -490 11 2007 Items[6].Count set value 64b
-data modify block -490 11 2007 Items[7].Count set value 64b
-data modify block -490 11 2007 Items[8].Count set value 64b
+data modify block -490 11 2007 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -490 50 2017 Items[0].Count set value 64b
-data modify block -490 50 2017 Items[1].Count set value 64b
-data modify block -490 50 2017 Items[2].Count set value 64b
-data modify block -490 50 2017 Items[3].Count set value 64b
-data modify block -490 50 2017 Items[4].Count set value 64b
-data modify block -490 50 2017 Items[5].Count set value 64b
-data modify block -490 50 2017 Items[6].Count set value 64b
-data modify block -490 50 2017 Items[7].Count set value 64b
-data modify block -490 50 2017 Items[8].Count set value 64b
+data modify block -490 50 2017 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -497 51 1980 Items[0].Count set value 64b
-data modify block -497 51 1980 Items[1].Count set value 64b
-data modify block -497 51 1980 Items[2].Count set value 64b
-data modify block -497 51 1980 Items[3].Count set value 64b
-data modify block -497 51 1980 Items[4].Count set value 64b
-data modify block -497 51 1980 Items[5].Count set value 64b
-data modify block -497 51 1980 Items[6].Count set value 64b
-data modify block -497 51 1980 Items[7].Count set value 64b
-data modify block -497 51 1980 Items[8].Count set value 64b
+data modify block -497 51 1980 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -502 16 1972 Items[0].Count set value 64b
-data modify block -502 16 1972 Items[1].Count set value 64b
-data modify block -502 16 1972 Items[2].Count set value 64b
-data modify block -502 16 1972 Items[3].Count set value 64b
-data modify block -502 16 1972 Items[4].Count set value 64b
-data modify block -502 16 1972 Items[5].Count set value 64b
-data modify block -502 16 1972 Items[6].Count set value 64b
-data modify block -502 16 1972 Items[7].Count set value 64b
-data modify block -502 16 1972 Items[8].Count set value 64b
+data modify block -502 16 1972 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -507 9 1951 Items[0].Count set value 64b
-data modify block -507 9 1951 Items[1].Count set value 64b
-data modify block -507 9 1951 Items[2].Count set value 64b
-data modify block -507 9 1951 Items[3].Count set value 64b
-data modify block -507 9 1951 Items[4].Count set value 64b
-data modify block -507 9 1951 Items[5].Count set value 64b
-data modify block -507 9 1951 Items[6].Count set value 64b
-data modify block -507 9 1951 Items[7].Count set value 64b
-data modify block -507 9 1951 Items[8].Count set value 64b
+data modify block -507 9 1951 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -509 14 2034 Items[0].Count set value 64b
-data modify block -509 14 2034 Items[1].Count set value 64b
-data modify block -509 14 2034 Items[2].Count set value 64b
-data modify block -509 14 2034 Items[3].Count set value 64b
-data modify block -509 14 2034 Items[4].Count set value 64b
-data modify block -509 14 2034 Items[5].Count set value 64b
-data modify block -509 14 2034 Items[6].Count set value 64b
-data modify block -509 14 2034 Items[7].Count set value 64b
-data modify block -509 14 2034 Items[8].Count set value 64b
+data modify block -509 14 2034 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -514 51 1962 Items[0].Count set value 64b
-data modify block -514 51 1962 Items[1].Count set value 64b
-data modify block -514 51 1962 Items[2].Count set value 64b
-data modify block -514 51 1962 Items[3].Count set value 64b
-data modify block -514 51 1962 Items[4].Count set value 64b
-data modify block -514 51 1962 Items[5].Count set value 64b
-data modify block -514 51 1962 Items[6].Count set value 64b
-data modify block -514 51 1962 Items[7].Count set value 64b
-data modify block -514 51 1962 Items[8].Count set value 64b
+data modify block -514 51 1962 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -516 46 2031 Items[0].Count set value 64b
-data modify block -516 46 2031 Items[1].Count set value 64b
-data modify block -516 46 2031 Items[2].Count set value 64b
-data modify block -516 46 2031 Items[3].Count set value 64b
-data modify block -516 46 2031 Items[4].Count set value 64b
-data modify block -516 46 2031 Items[5].Count set value 64b
-data modify block -516 46 2031 Items[6].Count set value 64b
-data modify block -516 46 2031 Items[7].Count set value 64b
-data modify block -516 46 2031 Items[8].Count set value 64b
+data modify block -516 46 2031 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -521 35 1982 Items[0].Count set value 64b
-data modify block -521 35 1982 Items[1].Count set value 64b
-data modify block -521 35 1982 Items[2].Count set value 64b
-data modify block -521 35 1982 Items[3].Count set value 64b
-data modify block -521 35 1982 Items[4].Count set value 64b
-data modify block -521 35 1982 Items[5].Count set value 64b
-data modify block -521 35 1982 Items[6].Count set value 64b
-data modify block -521 35 1982 Items[7].Count set value 64b
-data modify block -521 35 1982 Items[8].Count set value 64b
+data modify block -521 35 1982 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -527 51 1973 Items[0].Count set value 64b
-data modify block -527 51 1973 Items[1].Count set value 64b
-data modify block -527 51 1973 Items[2].Count set value 64b
-data modify block -527 51 1973 Items[3].Count set value 64b
-data modify block -527 51 1973 Items[4].Count set value 64b
-data modify block -527 51 1973 Items[5].Count set value 64b
-data modify block -527 51 1973 Items[6].Count set value 64b
-data modify block -527 51 1973 Items[7].Count set value 64b
-data modify block -527 51 1973 Items[8].Count set value 64b
+data modify block -527 51 1973 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -531 16 1990 Items[0].Count set value 64b
-data modify block -531 16 1990 Items[1].Count set value 64b
-data modify block -531 16 1990 Items[2].Count set value 64b
-data modify block -531 16 1990 Items[3].Count set value 64b
-data modify block -531 16 1990 Items[4].Count set value 64b
-data modify block -531 16 1990 Items[5].Count set value 64b
-data modify block -531 16 1990 Items[6].Count set value 64b
-data modify block -531 16 1990 Items[7].Count set value 64b
-data modify block -531 16 1990 Items[8].Count set value 64b
+data modify block -531 16 1990 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -532 44 2024 Items[0].Count set value 64b
-data modify block -532 44 2024 Items[1].Count set value 64b
-data modify block -532 44 2024 Items[2].Count set value 64b
-data modify block -532 44 2024 Items[3].Count set value 64b
-data modify block -532 44 2024 Items[4].Count set value 64b
-data modify block -532 44 2024 Items[5].Count set value 64b
-data modify block -532 44 2024 Items[6].Count set value 64b
-data modify block -532 44 2024 Items[7].Count set value 64b
-data modify block -532 44 2024 Items[8].Count set value 64b
+data modify block -532 44 2024 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -536 45 1948 Items[0].Count set value 64b
-data modify block -536 45 1948 Items[1].Count set value 64b
-data modify block -536 45 1948 Items[2].Count set value 64b
-data modify block -536 45 1948 Items[3].Count set value 64b
-data modify block -536 45 1948 Items[4].Count set value 64b
-data modify block -536 45 1948 Items[5].Count set value 64b
-data modify block -536 45 1948 Items[6].Count set value 64b
-data modify block -536 45 1948 Items[7].Count set value 64b
-data modify block -536 45 1948 Items[8].Count set value 64b
+data modify block -536 45 1948 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -546 51 2008 Items[0].Count set value 64b
-data modify block -546 51 2008 Items[1].Count set value 64b
-data modify block -546 51 2008 Items[2].Count set value 64b
-data modify block -546 51 2008 Items[3].Count set value 64b
-data modify block -546 51 2008 Items[4].Count set value 64b
-data modify block -546 51 2008 Items[5].Count set value 64b
-data modify block -546 51 2008 Items[6].Count set value 64b
-data modify block -546 51 2008 Items[7].Count set value 64b
-data modify block -546 51 2008 Items[8].Count set value 64b
+data modify block -546 51 2008 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -554 51 2007 Items[0].Count set value 64b
-data modify block -554 51 2007 Items[1].Count set value 64b
-data modify block -554 51 2007 Items[2].Count set value 64b
-data modify block -554 51 2007 Items[3].Count set value 64b
-data modify block -554 51 2007 Items[4].Count set value 64b
-data modify block -554 51 2007 Items[5].Count set value 64b
-data modify block -554 51 2007 Items[6].Count set value 64b
-data modify block -554 51 2007 Items[7].Count set value 64b
-data modify block -554 51 2007 Items[8].Count set value 64b
+data modify block -554 51 2007 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -557 45 1976 Items[0].Count set value 64b
-data modify block -557 45 1976 Items[1].Count set value 64b
-data modify block -557 45 1976 Items[2].Count set value 64b
-data modify block -557 45 1976 Items[3].Count set value 64b
-data modify block -557 45 1976 Items[4].Count set value 64b
-data modify block -557 45 1976 Items[5].Count set value 64b
-data modify block -557 45 1976 Items[6].Count set value 64b
-data modify block -557 45 1976 Items[7].Count set value 64b
-data modify block -557 45 1976 Items[8].Count set value 64b
+data modify block -557 45 1976 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -559 46 2022 Items[0].Count set value 64b
-data modify block -559 46 2022 Items[1].Count set value 64b
-data modify block -559 46 2022 Items[2].Count set value 64b
-data modify block -559 46 2022 Items[3].Count set value 64b
-data modify block -559 46 2022 Items[4].Count set value 64b
-data modify block -559 46 2022 Items[5].Count set value 64b
-data modify block -559 46 2022 Items[6].Count set value 64b
-data modify block -559 46 2022 Items[7].Count set value 64b
-data modify block -559 46 2022 Items[8].Count set value 64b
+data modify block -559 46 2022 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -561 47 1942 Items[0].Count set value 64b
-data modify block -561 47 1942 Items[1].Count set value 64b
-data modify block -561 47 1942 Items[2].Count set value 64b
-data modify block -561 47 1942 Items[3].Count set value 64b
-data modify block -561 47 1942 Items[4].Count set value 64b
-data modify block -561 47 1942 Items[5].Count set value 64b
-data modify block -561 47 1942 Items[6].Count set value 64b
-data modify block -561 47 1942 Items[7].Count set value 64b
-data modify block -561 47 1942 Items[8].Count set value 64b
+data modify block -561 47 1942 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -563 36 1999 Items[0].Count set value 64b
-data modify block -563 36 1999 Items[1].Count set value 64b
-data modify block -563 36 1999 Items[2].Count set value 64b
-data modify block -563 36 1999 Items[3].Count set value 64b
-data modify block -563 36 1999 Items[4].Count set value 64b
-data modify block -563 36 1999 Items[5].Count set value 64b
-data modify block -563 36 1999 Items[6].Count set value 64b
-data modify block -563 36 1999 Items[7].Count set value 64b
-data modify block -563 36 1999 Items[8].Count set value 64b
+data modify block -563 36 1999 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -578 15 1968 Items[0].Count set value 64b
-data modify block -578 15 1968 Items[1].Count set value 64b
-data modify block -578 15 1968 Items[2].Count set value 64b
-data modify block -578 15 1968 Items[3].Count set value 64b
-data modify block -578 15 1968 Items[4].Count set value 64b
-data modify block -578 15 1968 Items[5].Count set value 64b
-data modify block -578 15 1968 Items[6].Count set value 64b
-data modify block -578 15 1968 Items[7].Count set value 64b
-data modify block -578 15 1968 Items[8].Count set value 64b
+data modify block -578 15 1968 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -583 45 2012 Items[0].Count set value 64b
-data modify block -583 45 2012 Items[1].Count set value 64b
-data modify block -583 45 2012 Items[2].Count set value 64b
-data modify block -583 45 2012 Items[3].Count set value 64b
-data modify block -583 45 2012 Items[4].Count set value 64b
-data modify block -583 45 2012 Items[5].Count set value 64b
-data modify block -583 45 2012 Items[6].Count set value 64b
-data modify block -583 45 2012 Items[7].Count set value 64b
-data modify block -583 45 2012 Items[8].Count set value 64b
+data modify block -583 45 2012 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -588 52 1951 Items[0].Count set value 64b
-data modify block -588 52 1951 Items[1].Count set value 64b
-data modify block -588 52 1951 Items[2].Count set value 64b
-data modify block -588 52 1951 Items[3].Count set value 64b
-data modify block -588 52 1951 Items[4].Count set value 64b
-data modify block -588 52 1951 Items[5].Count set value 64b
-data modify block -588 52 1951 Items[6].Count set value 64b
-data modify block -588 52 1951 Items[7].Count set value 64b
-data modify block -588 52 1951 Items[8].Count set value 64b
+data modify block -588 52 1951 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -590 11 2032 Items[0].Count set value 64b
-data modify block -590 11 2032 Items[1].Count set value 64b
-data modify block -590 11 2032 Items[2].Count set value 64b
-data modify block -590 11 2032 Items[3].Count set value 64b
-data modify block -590 11 2032 Items[4].Count set value 64b
-data modify block -590 11 2032 Items[5].Count set value 64b
-data modify block -590 11 2032 Items[6].Count set value 64b
-data modify block -590 11 2032 Items[7].Count set value 64b
-data modify block -590 11 2032 Items[8].Count set value 64b
+data modify block -590 11 2032 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -590 46 1978 Items[0].Count set value 64b
-data modify block -590 46 1978 Items[1].Count set value 64b
-data modify block -590 46 1978 Items[2].Count set value 64b
-data modify block -590 46 1978 Items[3].Count set value 64b
-data modify block -590 46 1978 Items[4].Count set value 64b
-data modify block -590 46 1978 Items[5].Count set value 64b
-data modify block -590 46 1978 Items[6].Count set value 64b
-data modify block -590 46 1978 Items[7].Count set value 64b
-data modify block -590 46 1978 Items[8].Count set value 64b
+data modify block -590 46 1978 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -594 12 1954 Items[0].Count set value 64b
-data modify block -594 12 1954 Items[1].Count set value 64b
-data modify block -594 12 1954 Items[2].Count set value 64b
-data modify block -594 12 1954 Items[3].Count set value 64b
-data modify block -594 12 1954 Items[4].Count set value 64b
-data modify block -594 12 1954 Items[5].Count set value 64b
-data modify block -594 12 1954 Items[6].Count set value 64b
-data modify block -594 12 1954 Items[7].Count set value 64b
-data modify block -594 12 1954 Items[8].Count set value 64b
+data modify block -594 12 1954 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -597 12 2009 Items[0].Count set value 64b
-data modify block -597 12 2009 Items[1].Count set value 64b
-data modify block -597 12 2009 Items[2].Count set value 64b
-data modify block -597 12 2009 Items[3].Count set value 64b
-data modify block -597 12 2009 Items[4].Count set value 64b
-data modify block -597 12 2009 Items[5].Count set value 64b
-data modify block -597 12 2009 Items[6].Count set value 64b
-data modify block -597 12 2009 Items[7].Count set value 64b
-data modify block -597 12 2009 Items[8].Count set value 64b
+data modify block -597 12 2009 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -598 11 1988 Items[0].Count set value 64b
-data modify block -598 11 1988 Items[1].Count set value 64b
-data modify block -598 11 1988 Items[2].Count set value 64b
-data modify block -598 11 1988 Items[3].Count set value 64b
-data modify block -598 11 1988 Items[4].Count set value 64b
-data modify block -598 11 1988 Items[5].Count set value 64b
-data modify block -598 11 1988 Items[6].Count set value 64b
-data modify block -598 11 1988 Items[7].Count set value 64b
-data modify block -598 11 1988 Items[8].Count set value 64b
+data modify block -598 11 1988 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -606 43 2024 Items[0].Count set value 64b
-data modify block -606 43 2024 Items[1].Count set value 64b
-data modify block -606 43 2024 Items[2].Count set value 64b
-data modify block -606 43 2024 Items[3].Count set value 64b
-data modify block -606 43 2024 Items[4].Count set value 64b
-data modify block -606 43 2024 Items[5].Count set value 64b
-data modify block -606 43 2024 Items[6].Count set value 64b
-data modify block -606 43 2024 Items[7].Count set value 64b
-data modify block -606 43 2024 Items[8].Count set value 64b
+data modify block -606 43 2024 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -619 43 2027 Items[0].Count set value 64b
-data modify block -619 43 2027 Items[1].Count set value 64b
-data modify block -619 43 2027 Items[2].Count set value 64b
-data modify block -619 43 2027 Items[3].Count set value 64b
-data modify block -619 43 2027 Items[4].Count set value 64b
-data modify block -619 43 2027 Items[5].Count set value 64b
-data modify block -619 43 2027 Items[6].Count set value 64b
-data modify block -619 43 2027 Items[7].Count set value 64b
-data modify block -619 43 2027 Items[8].Count set value 64b
+data modify block -619 43 2027 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -628 1 1920 Items[0].Count set value 64b
-data modify block -628 1 1920 Items[1].Count set value 64b
-data modify block -628 1 1920 Items[2].Count set value 64b
-data modify block -628 1 1920 Items[3].Count set value 64b
-data modify block -628 1 1920 Items[4].Count set value 64b
-data modify block -628 1 1920 Items[5].Count set value 64b
-data modify block -628 1 1920 Items[6].Count set value 64b
-data modify block -628 1 1920 Items[7].Count set value 64b
-data modify block -628 1 1920 Items[8].Count set value 64b
+data modify block -628 1 1920 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Coin"
-data modify block -640 -19 1888 Items[0].Count set value 64b
-data modify block -640 -19 1888 Items[1].Count set value 64b
-data modify block -640 -19 1888 Items[2].Count set value 64b
-data modify block -640 -19 1888 Items[3].Count set value 64b
-data modify block -640 -19 1888 Items[4].Count set value 64b
-data modify block -640 -19 1888 Items[5].Count set value 64b
-data modify block -640 -19 1888 Items[6].Count set value 64b
-data modify block -640 -19 1888 Items[7].Count set value 64b
-data modify block -640 -19 1888 Items[8].Count set value 64b
+data modify block -640 -19 1888 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -496 15 2000 Items[0].Count set value 64b
-data modify block -496 15 2000 Items[1].Count set value 64b
-data modify block -496 15 2000 Items[2].Count set value 64b
-data modify block -496 15 2000 Items[3].Count set value 64b
-data modify block -496 15 2000 Items[4].Count set value 64b
-data modify block -496 15 2000 Items[5].Count set value 64b
-data modify block -496 15 2000 Items[6].Count set value 64b
-data modify block -496 15 2000 Items[7].Count set value 64b
-data modify block -496 15 2000 Items[8].Count set value 64b
+data modify block -496 15 2000 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -523 12 2042 Items[0].Count set value 64b
-data modify block -523 12 2042 Items[1].Count set value 64b
-data modify block -523 12 2042 Items[2].Count set value 64b
-data modify block -523 12 2042 Items[3].Count set value 64b
-data modify block -523 12 2042 Items[4].Count set value 64b
-data modify block -523 12 2042 Items[5].Count set value 64b
-data modify block -523 12 2042 Items[6].Count set value 64b
-data modify block -523 12 2042 Items[7].Count set value 64b
-data modify block -523 12 2042 Items[8].Count set value 64b
+data modify block -523 12 2042 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -526 12 1942 Items[0].Count set value 64b
-data modify block -526 12 1942 Items[1].Count set value 64b
-data modify block -526 12 1942 Items[2].Count set value 64b
-data modify block -526 12 1942 Items[3].Count set value 64b
-data modify block -526 12 1942 Items[4].Count set value 64b
-data modify block -526 12 1942 Items[5].Count set value 64b
-data modify block -526 12 1942 Items[6].Count set value 64b
-data modify block -526 12 1942 Items[7].Count set value 64b
-data modify block -526 12 1942 Items[8].Count set value 64b
+data modify block -526 12 1942 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -528 12 2031 Items[0].Count set value 64b
-data modify block -528 12 2031 Items[1].Count set value 64b
-data modify block -528 12 2031 Items[2].Count set value 64b
-data modify block -528 12 2031 Items[3].Count set value 64b
-data modify block -528 12 2031 Items[4].Count set value 64b
-data modify block -528 12 2031 Items[5].Count set value 64b
-data modify block -528 12 2031 Items[6].Count set value 64b
-data modify block -528 12 2031 Items[7].Count set value 64b
-data modify block -528 12 2031 Items[8].Count set value 64b
+data modify block -528 12 2031 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -541 11 1998 Items[0].Count set value 64b
-data modify block -541 11 1998 Items[1].Count set value 64b
-data modify block -541 11 1998 Items[2].Count set value 64b
-data modify block -541 11 1998 Items[3].Count set value 64b
-data modify block -541 11 1998 Items[4].Count set value 64b
-data modify block -541 11 1998 Items[5].Count set value 64b
-data modify block -541 11 1998 Items[6].Count set value 64b
-data modify block -541 11 1998 Items[7].Count set value 64b
-data modify block -541 11 1998 Items[8].Count set value 64b
+data modify block -541 11 1998 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -548 11 1975 Items[0].Count set value 64b
-data modify block -548 11 1975 Items[1].Count set value 64b
-data modify block -548 11 1975 Items[2].Count set value 64b
-data modify block -548 11 1975 Items[3].Count set value 64b
-data modify block -548 11 1975 Items[4].Count set value 64b
-data modify block -548 11 1975 Items[5].Count set value 64b
-data modify block -548 11 1975 Items[6].Count set value 64b
-data modify block -548 11 1975 Items[7].Count set value 64b
-data modify block -548 11 1975 Items[8].Count set value 64b
+data modify block -548 11 1975 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -568 8 1964 Items[0].Count set value 64b
-data modify block -568 8 1964 Items[1].Count set value 64b
-data modify block -568 8 1964 Items[2].Count set value 64b
-data modify block -568 8 1964 Items[3].Count set value 64b
-data modify block -568 8 1964 Items[4].Count set value 64b
-data modify block -568 8 1964 Items[5].Count set value 64b
-data modify block -568 8 1964 Items[6].Count set value 64b
-data modify block -568 8 1964 Items[7].Count set value 64b
-data modify block -568 8 1964 Items[8].Count set value 64b
+data modify block -568 8 1964 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -574 11 2007 Items[0].Count set value 64b
-data modify block -574 11 2007 Items[1].Count set value 64b
-data modify block -574 11 2007 Items[2].Count set value 64b
-data modify block -574 11 2007 Items[3].Count set value 64b
-data modify block -574 11 2007 Items[4].Count set value 64b
-data modify block -574 11 2007 Items[5].Count set value 64b
-data modify block -574 11 2007 Items[6].Count set value 64b
-data modify block -574 11 2007 Items[7].Count set value 64b
-data modify block -574 11 2007 Items[8].Count set value 64b
+data modify block -574 11 2007 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -575 36 1998 Items[0].Count set value 64b
-data modify block -575 36 1998 Items[1].Count set value 64b
-data modify block -575 36 1998 Items[2].Count set value 64b
-data modify block -575 36 1998 Items[3].Count set value 64b
-data modify block -575 36 1998 Items[4].Count set value 64b
-data modify block -575 36 1998 Items[5].Count set value 64b
-data modify block -575 36 1998 Items[6].Count set value 64b
-data modify block -575 36 1998 Items[7].Count set value 64b
-data modify block -575 36 1998 Items[8].Count set value 64b
+data modify block -575 36 1998 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -577 -37 1837 Items[0].Count set value 64b
-data modify block -577 -37 1837 Items[1].Count set value 64b
-data modify block -577 -37 1837 Items[2].Count set value 64b
-data modify block -577 -37 1837 Items[3].Count set value 64b
-data modify block -577 -37 1837 Items[4].Count set value 64b
-data modify block -577 -37 1837 Items[5].Count set value 64b
-data modify block -577 -37 1837 Items[6].Count set value 64b
-data modify block -577 -37 1837 Items[7].Count set value 64b
-data modify block -577 -37 1837 Items[8].Count set value 64b
+data modify block -577 -37 1837 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -578 15 1970 Items[0].Count set value 64b
-data modify block -578 15 1970 Items[1].Count set value 64b
-data modify block -578 15 1970 Items[2].Count set value 64b
-data modify block -578 15 1970 Items[3].Count set value 64b
-data modify block -578 15 1970 Items[4].Count set value 64b
-data modify block -578 15 1970 Items[5].Count set value 64b
-data modify block -578 15 1970 Items[6].Count set value 64b
-data modify block -578 15 1970 Items[7].Count set value 64b
-data modify block -578 15 1970 Items[8].Count set value 64b
+data modify block -578 15 1970 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -581 9 1955 Items[0].Count set value 64b
-data modify block -581 9 1955 Items[1].Count set value 64b
-data modify block -581 9 1955 Items[2].Count set value 64b
-data modify block -581 9 1955 Items[3].Count set value 64b
-data modify block -581 9 1955 Items[4].Count set value 64b
-data modify block -581 9 1955 Items[5].Count set value 64b
-data modify block -581 9 1955 Items[6].Count set value 64b
-data modify block -581 9 1955 Items[7].Count set value 64b
-data modify block -581 9 1955 Items[8].Count set value 64b
+data modify block -581 9 1955 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -583 -17 1927 Items[0].Count set value 64b
-data modify block -583 -17 1927 Items[1].Count set value 64b
-data modify block -583 -17 1927 Items[2].Count set value 64b
-data modify block -583 -17 1927 Items[3].Count set value 64b
-data modify block -583 -17 1927 Items[4].Count set value 64b
-data modify block -583 -17 1927 Items[5].Count set value 64b
-data modify block -583 -17 1927 Items[6].Count set value 64b
-data modify block -583 -17 1927 Items[7].Count set value 64b
-data modify block -583 -17 1927 Items[8].Count set value 64b
+data modify block -583 -17 1927 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -585 -9 1919 Items[0].Count set value 64b
-data modify block -585 -9 1919 Items[1].Count set value 64b
-data modify block -585 -9 1919 Items[2].Count set value 64b
-data modify block -585 -9 1919 Items[3].Count set value 64b
-data modify block -585 -9 1919 Items[4].Count set value 64b
-data modify block -585 -9 1919 Items[5].Count set value 64b
-data modify block -585 -9 1919 Items[6].Count set value 64b
-data modify block -585 -9 1919 Items[7].Count set value 64b
-data modify block -585 -9 1919 Items[8].Count set value 64b
+data modify block -585 -9 1919 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -586 1 1887 Items[0].Count set value 64b
-data modify block -586 1 1887 Items[1].Count set value 64b
-data modify block -586 1 1887 Items[2].Count set value 64b
-data modify block -586 1 1887 Items[3].Count set value 64b
-data modify block -586 1 1887 Items[4].Count set value 64b
-data modify block -586 1 1887 Items[5].Count set value 64b
-data modify block -586 1 1887 Items[6].Count set value 64b
-data modify block -586 1 1887 Items[7].Count set value 64b
-data modify block -586 1 1887 Items[8].Count set value 64b
+data modify block -586 1 1887 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -590 1 1901 Items[0].Count set value 64b
-data modify block -590 1 1901 Items[1].Count set value 64b
-data modify block -590 1 1901 Items[2].Count set value 64b
-data modify block -590 1 1901 Items[3].Count set value 64b
-data modify block -590 1 1901 Items[4].Count set value 64b
-data modify block -590 1 1901 Items[5].Count set value 64b
-data modify block -590 1 1901 Items[6].Count set value 64b
-data modify block -590 1 1901 Items[7].Count set value 64b
-data modify block -590 1 1901 Items[8].Count set value 64b
+data modify block -590 1 1901 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -603 -9 1885 Items[0].Count set value 64b
-data modify block -603 -9 1885 Items[1].Count set value 64b
-data modify block -603 -9 1885 Items[2].Count set value 64b
-data modify block -603 -9 1885 Items[3].Count set value 64b
-data modify block -603 -9 1885 Items[4].Count set value 64b
-data modify block -603 -9 1885 Items[5].Count set value 64b
-data modify block -603 -9 1885 Items[6].Count set value 64b
-data modify block -603 -9 1885 Items[7].Count set value 64b
-data modify block -603 -9 1885 Items[8].Count set value 64b
+data modify block -603 -9 1885 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -606 1 1920 Items[0].Count set value 64b
-data modify block -606 1 1920 Items[1].Count set value 64b
-data modify block -606 1 1920 Items[2].Count set value 64b
-data modify block -606 1 1920 Items[3].Count set value 64b
-data modify block -606 1 1920 Items[4].Count set value 64b
-data modify block -606 1 1920 Items[5].Count set value 64b
-data modify block -606 1 1920 Items[6].Count set value 64b
-data modify block -606 1 1920 Items[7].Count set value 64b
-data modify block -606 1 1920 Items[8].Count set value 64b
+data modify block -606 1 1920 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -608 -19 1919 Items[0].Count set value 64b
-data modify block -608 -19 1919 Items[1].Count set value 64b
-data modify block -608 -19 1919 Items[2].Count set value 64b
-data modify block -608 -19 1919 Items[3].Count set value 64b
-data modify block -608 -19 1919 Items[4].Count set value 64b
-data modify block -608 -19 1919 Items[5].Count set value 64b
-data modify block -608 -19 1919 Items[6].Count set value 64b
-data modify block -608 -19 1919 Items[7].Count set value 64b
-data modify block -608 -19 1919 Items[8].Count set value 64b
+data modify block -608 -19 1919 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -632 -12 1990 Items[0].Count set value 64b
-data modify block -632 -12 1990 Items[1].Count set value 64b
-data modify block -632 -12 1990 Items[2].Count set value 64b
-data modify block -632 -12 1990 Items[3].Count set value 64b
-data modify block -632 -12 1990 Items[4].Count set value 64b
-data modify block -632 -12 1990 Items[5].Count set value 64b
-data modify block -632 -12 1990 Items[6].Count set value 64b
-data modify block -632 -12 1990 Items[7].Count set value 64b
-data modify block -632 -12 1990 Items[8].Count set value 64b
+data modify block -632 -12 1990 Items[].Count set value 64b
 
 ## Example Item: "Decked Out Crown"
-data modify block -654 -9 1891 Items[0].Count set value 64b
-data modify block -654 -9 1891 Items[1].Count set value 64b
-data modify block -654 -9 1891 Items[2].Count set value 64b
-data modify block -654 -9 1891 Items[3].Count set value 64b
-data modify block -654 -9 1891 Items[4].Count set value 64b
-data modify block -654 -9 1891 Items[5].Count set value 64b
-data modify block -654 -9 1891 Items[6].Count set value 64b
-data modify block -654 -9 1891 Items[7].Count set value 64b
-data modify block -654 -9 1891 Items[8].Count set value 64b
+data modify block -654 -9 1891 Items[].Count set value 64b
 
 ## Example Item: "The Black Mines Key"
-data modify block -503 31 1975 Items[0].Count set value 64b
-data modify block -503 31 1975 Items[1].Count set value 64b
-data modify block -503 31 1975 Items[2].Count set value 64b
-data modify block -503 31 1975 Items[3].Count set value 64b
-data modify block -503 31 1975 Items[4].Count set value 64b
-data modify block -503 31 1975 Items[5].Count set value 64b
-data modify block -503 31 1975 Items[6].Count set value 64b
-data modify block -503 31 1975 Items[7].Count set value 64b
-data modify block -503 31 1975 Items[8].Count set value 64b
+data modify block -503 31 1975 Items[].Count set value 64b
 
 ## Example Item: "The Black Mines Key"
-data modify block -553 10 2036 Items[0].Count set value 64b
-data modify block -553 10 2036 Items[1].Count set value 64b
-data modify block -553 10 2036 Items[2].Count set value 64b
-data modify block -553 10 2036 Items[3].Count set value 64b
-data modify block -553 10 2036 Items[4].Count set value 64b
-data modify block -553 10 2036 Items[5].Count set value 64b
-data modify block -553 10 2036 Items[6].Count set value 64b
-data modify block -553 10 2036 Items[7].Count set value 64b
-data modify block -553 10 2036 Items[8].Count set value 64b
+data modify block -553 10 2036 Items[].Count set value 64b
 
 ## Example Item: "The Burning Dark Key"
-data modify block -624 -9 1924 Items[0].Count set value 64b
-data modify block -624 -9 1924 Items[1].Count set value 64b
-data modify block -624 -9 1924 Items[2].Count set value 64b
-data modify block -624 -9 1924 Items[3].Count set value 64b
-data modify block -624 -9 1924 Items[4].Count set value 64b
-data modify block -624 -9 1924 Items[5].Count set value 64b
-data modify block -624 -9 1924 Items[6].Count set value 64b
-data modify block -624 -9 1924 Items[7].Count set value 64b
-data modify block -624 -9 1924 Items[8].Count set value 64b
+data modify block -624 -9 1924 Items[].Count set value 64b
 
 ## Example Item: "The Burning Dark Key"
-data modify block -641 -19 1921 Items[0].Count set value 64b
-data modify block -641 -19 1921 Items[1].Count set value 64b
-data modify block -641 -19 1921 Items[2].Count set value 64b
-data modify block -641 -19 1921 Items[3].Count set value 64b
-data modify block -641 -19 1921 Items[4].Count set value 64b
-data modify block -641 -19 1921 Items[5].Count set value 64b
-data modify block -641 -19 1921 Items[6].Count set value 64b
-data modify block -641 -19 1921 Items[7].Count set value 64b
-data modify block -641 -19 1921 Items[8].Count set value 64b
+data modify block -641 -19 1921 Items[].Count set value 64b
 
 ## Example Item: "The Burning Dark Key"
-data modify block -644 1 1920 Items[0].Count set value 64b
-data modify block -644 1 1920 Items[1].Count set value 64b
-data modify block -644 1 1920 Items[2].Count set value 64b
-data modify block -644 1 1920 Items[3].Count set value 64b
-data modify block -644 1 1920 Items[4].Count set value 64b
-data modify block -644 1 1920 Items[5].Count set value 64b
-data modify block -644 1 1920 Items[6].Count set value 64b
-data modify block -644 1 1920 Items[7].Count set value 64b
-data modify block -644 1 1920 Items[8].Count set value 64b
+data modify block -644 1 1920 Items[].Count set value 64b
 
 ## Example Item: "The Burning Dark Key"
-data modify block -652 1 1893 Items[0].Count set value 64b
-data modify block -652 1 1893 Items[1].Count set value 64b
-data modify block -652 1 1893 Items[2].Count set value 64b
-data modify block -652 1 1893 Items[3].Count set value 64b
-data modify block -652 1 1893 Items[4].Count set value 64b
-data modify block -652 1 1893 Items[5].Count set value 64b
-data modify block -652 1 1893 Items[6].Count set value 64b
-data modify block -652 1 1893 Items[7].Count set value 64b
-data modify block -652 1 1893 Items[8].Count set value 64b
+data modify block -652 1 1893 Items[].Count set value 64b
 
 ## Example Item: "The Caves of Carnage Key"
-data modify block -513 37 1992 Items[0].Count set value 64b
-data modify block -513 37 1992 Items[1].Count set value 64b
-data modify block -513 37 1992 Items[2].Count set value 64b
-data modify block -513 37 1992 Items[3].Count set value 64b
-data modify block -513 37 1992 Items[4].Count set value 64b
-data modify block -513 37 1992 Items[5].Count set value 64b
-data modify block -513 37 1992 Items[6].Count set value 64b
-data modify block -513 37 1992 Items[7].Count set value 64b
-data modify block -513 37 1992 Items[8].Count set value 64b
+data modify block -513 37 1992 Items[].Count set value 64b
 
 ## Example Item: "The Caves of Carnage Key"
-data modify block -518 35 2002 Items[0].Count set value 64b
-data modify block -518 35 2002 Items[1].Count set value 64b
-data modify block -518 35 2002 Items[2].Count set value 64b
-data modify block -518 35 2002 Items[3].Count set value 64b
-data modify block -518 35 2002 Items[4].Count set value 64b
-data modify block -518 35 2002 Items[5].Count set value 64b
-data modify block -518 35 2002 Items[6].Count set value 64b
-data modify block -518 35 2002 Items[7].Count set value 64b
-data modify block -518 35 2002 Items[8].Count set value 64b
+data modify block -518 35 2002 Items[].Count set value 64b
 
 ## Example Item: "The Caves of Carnage Key"
-data modify block -519 53 2011 Items[0].Count set value 64b
-data modify block -519 53 2011 Items[1].Count set value 64b
-data modify block -519 53 2011 Items[2].Count set value 64b
-data modify block -519 53 2011 Items[3].Count set value 64b
-data modify block -519 53 2011 Items[4].Count set value 64b
-data modify block -519 53 2011 Items[5].Count set value 64b
-data modify block -519 53 2011 Items[6].Count set value 64b
-data modify block -519 53 2011 Items[7].Count set value 64b
-data modify block -519 53 2011 Items[8].Count set value 64b
+data modify block -519 53 2011 Items[].Count set value 64b
+


### PR DESCRIPTION
Refilling of all droppers I managed to crawl out of world download. For every dropper in the dungeon it tries to set each slot count to 64. For empty slots this doesn't seem to do anything so it looks fine. This works for suit up armor - which as weird as having stack of diamond armor is, doesn't sound like a problem as well.

Droppers were prefiltered based on content - I removed those with non-interesting item in first slot, and also ones where item count was 1 (Tango used coins in some of randomizers). I also removed some of the card randomizer droppers.

However this list still might be both missing some droppers (e.g. ones that didn't get refilled by Tango and were empty in world download) and have some droppers that shouldn't be refilled.